### PR TITLE
#212 Fix blurry footer payment logo by using correct intrinsic image dimensions

### DIFF
--- a/apps/web/components/Layout/Footer/index.tsx
+++ b/apps/web/components/Layout/Footer/index.tsx
@@ -15,6 +15,7 @@ import {
   Divider,
   CardWrapper,
   LinkRow,
+  PaymentCardImage,
 } from "./styles";
 import Image from "next/image";
 import logo from "../../../assets/images/kiibee-logo.svg";
@@ -81,11 +82,11 @@ const Footer = () => {
             </MonoText>
           </LinkRow>
           <CardWrapper>
-            <Image
-              src={card.src ?? card}
+            <PaymentCardImage
+              src={card}
               alt={t("nav.logoAlt")}
-              width={48}
-              height={32}
+              width={card.width}
+              height={card.height}
             />
           </CardWrapper>
         </BottomRight>

--- a/apps/web/components/Layout/Footer/styles.ts
+++ b/apps/web/components/Layout/Footer/styles.ts
@@ -1,6 +1,7 @@
 import Link from "next/link";
+import Image from "next/image";
 import styled from "styled-components";
-import { media } from "@repo/ui/breakpoints";
+import breakpoints, { media } from "@repo/ui/breakpoints";
 
 export const Container = styled.footer`
   background: ${({ theme }) => theme.colors.primary.GREEN_100};
@@ -101,8 +102,16 @@ export const CardWrapper = styled.div`
   margin-top: 10px;
   display: flex;
   justify-content: flex-end;
-  img {
-    height: 28px;
-    width: auto;
+  width: min(45vw, 14rem);
+
+  ${media.tablet} {
+    width: min(60vw, 12rem);
   }
+`;
+
+export const PaymentCardImage = styled(Image).attrs({
+  sizes: `(max-width: ${breakpoints.tablet}) 60vw, 45vw`,
+})`
+  width: 100%;
+  height: auto;
 `;


### PR DESCRIPTION
# Description
Fixed. The footer blur came from a size mismatch in next/image:

It was requesting 48x32 but CSS displayed it around 203x28, so the browser upscaled a tiny source.
I changed it to use the image’s real intrinsic size (card.width / card.height) plus responsive sizes, so it now renders sharp.

Fixes #212

## Type of change

# Before
<img width="405" height="195" alt="image" src="https://github.com/user-attachments/assets/0a14165e-35ee-4baf-89ba-f242363d8a44" />

# After
<img width="493" height="201" alt="image" src="https://github.com/user-attachments/assets/036078f8-f952-4874-a7d4-4d2d0361388c" />

