### PR TITLE
233: Use React.memo on DiscoverContent card to prevent re-renders

### DIFF
--- a/apps/web/components/Feature/landing/DiscoverContent/DiscoverCard.tsx
+++ b/apps/web/components/Feature/landing/DiscoverContent/DiscoverCard.tsx
@@ -26,6 +26,7 @@ import {
 
 type Props = {
   item: DiscoverContentItem;
+  lng?: string;
 };
 
 function DiscoverCard({ item }: Props) {
@@ -99,4 +100,8 @@ function DiscoverCard({ item }: Props) {
   );
 }
 
-export default memo(DiscoverCard, (prev, next) => prev.item === next.item);
+export default memo(
+  DiscoverCard,
+  (prev: Readonly<Props>, next: Readonly<Props>) =>
+    prev.item === next.item && prev.lng === next.lng,
+);

--- a/apps/web/components/Feature/landing/DiscoverContent/DiscoverCard.tsx
+++ b/apps/web/components/Feature/landing/DiscoverContent/DiscoverCard.tsx
@@ -5,6 +5,7 @@ import { memo } from "react";
 import { useTheme } from "styled-components";
 import { useTranslation } from "react-i18next";
 import { EbookIcon, VideoIcon } from "@/assets/icons";
+import { MEDIA_TYPE } from "@/utils/Constants";
 import type { DiscoverContentItem } from "@/utils/discoverContent";
 import { MonoText } from "@/components/UI/Monotext";
 import COLORS from "@repo/ui/colors";
@@ -65,7 +66,7 @@ function DiscoverCard({ item }: Props) {
 
         <MediaTypeBox>
           <IconFrame>
-            {item.mediaType === "epub" ? (
+            {item.mediaType === MEDIA_TYPE.EPUB ? (
               <EbookIcon
                 width={24}
                 height={24}

--- a/apps/web/components/Feature/landing/DiscoverContent/DiscoverCard.tsx
+++ b/apps/web/components/Feature/landing/DiscoverContent/DiscoverCard.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import Image from "next/image";
+import { memo } from "react";
+import { useTheme } from "styled-components";
+import { useTranslation } from "react-i18next";
+import { EbookIcon, VideoIcon } from "@/assets/icons";
+import type { DiscoverContentItem } from "@/utils/discoverContent";
+import { MonoText } from "@/components/UI/Monotext";
+import COLORS from "@repo/ui/colors";
+import {
+  Card,
+  ImageContainer,
+  CategoryBadge,
+  TextSection,
+  CardTitle,
+  CardAuthor,
+  CardDate,
+  MediaTypeBox,
+  ActionsContainer,
+  ActionButton,
+  FullWidthAction,
+  IconFrame,
+} from "./styles";
+
+type Props = {
+  item: DiscoverContentItem;
+};
+
+function DiscoverCard({ item }: Props) {
+  const theme = useTheme();
+  const { t } = useTranslation();
+
+  return (
+    <Card>
+      <ImageContainer>
+        <CategoryBadge>
+          <MonoText $use="Body_Bold" color={COLORS.primary.BLACK_90}>
+            {t(item.categoryKey)}
+          </MonoText>
+        </CategoryBadge>
+        <Image
+          src={item.image}
+          alt={t(item.titleKey)}
+          fill
+          sizes="(max-width: 767px) 100vw, (max-width: 1199px) 50vw, 33vw"
+          style={{ objectFit: "cover" }}
+        />
+      </ImageContainer>
+
+      <TextSection>
+        <CardTitle>
+          <MonoText $use="H5_Medium">{t(item.titleKey)}</MonoText>
+        </CardTitle>
+        <CardAuthor>
+          <MonoText $use="Body_Medium" color={COLORS.primary.BLACK_90}>
+            {t(item.authorKey)}
+          </MonoText>
+        </CardAuthor>
+        <CardDate>
+          <MonoText $use="Body_Medium" color={COLORS.neutral.GRAY_400}>
+            {t(item.dateKey)}
+          </MonoText>
+        </CardDate>
+
+        <MediaTypeBox>
+          <IconFrame>
+            {item.mediaType === "epub" ? (
+              <EbookIcon
+                width={24}
+                height={24}
+                color={theme.colors.neutral.BLACK}
+              />
+            ) : (
+              <VideoIcon color={theme.colors.neutral.BLACK} />
+            )}
+          </IconFrame>
+          <MonoText $use="Body_Bold" color={COLORS.primary.BLACK_90}>
+            {t(item.mediaTypeKey)}
+          </MonoText>
+        </MediaTypeBox>
+      </TextSection>
+
+      <ActionsContainer>
+        {item.actions.map((action) =>
+          action.fullWidth ? (
+            <FullWidthAction key={action.labelKey}>
+              {t(action.labelKey)}
+            </FullWidthAction>
+          ) : (
+            <ActionButton key={action.labelKey}>
+              {t(action.labelKey)}
+            </ActionButton>
+          ),
+        )}
+      </ActionsContainer>
+    </Card>
+  );
+}
+
+export default memo(DiscoverCard, (prev, next) => prev.item === next.item);

--- a/apps/web/components/Feature/landing/DiscoverContent/index.tsx
+++ b/apps/web/components/Feature/landing/DiscoverContent/index.tsx
@@ -16,7 +16,7 @@ import GenericButton from "@/components/UI/GenericButton";
 import { VARIANT } from "@/utils/Constants";
 
 export default function DiscoverContent() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   return (
     <Section>
@@ -31,7 +31,7 @@ export default function DiscoverContent() {
 
       <GridContainer>
         {discoverContentData.map((item) => (
-          <DiscoverCard key={item.id} item={item} />
+          <DiscoverCard key={item.id} item={item} lng={i18n.language} />
         ))}
       </GridContainer>
 

--- a/apps/web/components/Feature/landing/DiscoverContent/index.tsx
+++ b/apps/web/components/Feature/landing/DiscoverContent/index.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-import Image from "next/image";
-import { useTheme } from "styled-components";
 import { useTranslation } from "react-i18next";
-import { EbookIcon, VideoIcon } from "@/assets/icons";
 import { discoverContentData } from "@/utils/discoverContent";
 import {
   Section,
@@ -11,27 +8,14 @@ import {
   Title,
   Subtitle,
   GridContainer,
-  Card,
-  ImageContainer,
-  CategoryBadge,
-  TextSection,
-  CardTitle,
-  CardAuthor,
-  CardDate,
-  MediaTypeBox,
-  ActionsContainer,
-  ActionButton,
-  FullWidthAction,
   BottomCtaSection,
-  IconFrame,
 } from "./styles";
+import DiscoverCard from "./DiscoverCard";
 import { MonoText } from "@/components/UI/Monotext";
-import COLORS from "@repo/ui/colors";
 import GenericButton from "@/components/UI/GenericButton";
 import { VARIANT } from "@/utils/Constants";
 
 export default function DiscoverContent() {
-  const theme = useTheme();
   const { t } = useTranslation();
 
   return (
@@ -47,70 +31,7 @@ export default function DiscoverContent() {
 
       <GridContainer>
         {discoverContentData.map((item) => (
-          <Card key={item.id}>
-            <ImageContainer>
-              <CategoryBadge>
-                <MonoText
-                  $use="Body_Bold"
-                  color={COLORS.primary.BLACK_90}
-                ></MonoText>
-              </CategoryBadge>
-              <Image
-                src={item.image}
-                alt={t(item.titleKey)}
-                fill
-                sizes="(max-width: 767px) 100vw, (max-width: 1199px) 50vw, 33vw"
-                style={{ objectFit: "cover" }}
-              />
-            </ImageContainer>
-
-            <TextSection>
-              <CardTitle>
-                <MonoText $use="H5_Medium">{t(item.titleKey)}</MonoText>
-              </CardTitle>
-              <CardAuthor>
-                <MonoText $use="Body_Medium" color={COLORS.primary.BLACK_90}>
-                  {t(item.authorKey)}
-                </MonoText>
-              </CardAuthor>
-              <CardDate>
-                <MonoText $use="Body_Medium" color={COLORS.neutral.GRAY_400}>
-                  {t(item.dateKey)}
-                </MonoText>
-              </CardDate>
-
-              <MediaTypeBox>
-                <IconFrame>
-                  {item.mediaType === "epub" ? (
-                    <EbookIcon
-                      width={24}
-                      height={24}
-                      color={theme.colors.neutral.BLACK}
-                    />
-                  ) : (
-                    <VideoIcon color={theme.colors.neutral.BLACK} />
-                  )}
-                </IconFrame>
-                <MonoText $use="Body_Bold" color={COLORS.primary.BLACK_90}>
-                  {t(item.mediaTypeKey)}
-                </MonoText>
-              </MediaTypeBox>
-            </TextSection>
-
-            <ActionsContainer>
-              {item.actions.map((action) =>
-                action.fullWidth ? (
-                  <FullWidthAction key={action.labelKey}>
-                    {t(action.labelKey)}
-                  </FullWidthAction>
-                ) : (
-                  <ActionButton key={action.labelKey}>
-                    {t(action.labelKey)}
-                  </ActionButton>
-                ),
-              )}
-            </ActionsContainer>
-          </Card>
+          <DiscoverCard key={item.id} item={item} />
         ))}
       </GridContainer>
 

--- a/apps/web/utils/Constants.ts
+++ b/apps/web/utils/Constants.ts
@@ -33,6 +33,11 @@ export const SIZE = {
   SM: "sm",
 } as const;
 export type SIZE = (typeof SIZE)[keyof typeof SIZE];
+export const MEDIA_TYPE = {
+  VIDEO: "video",
+  EPUB: "epub",
+} as const;
+export type MediaType = (typeof MEDIA_TYPE)[keyof typeof MEDIA_TYPE];
 const KEY_SPACE = " ";
 const KEY_SPACEBAR = "Spacebar";
 export const FAQ_TOGGLE_KEYS = [KEY_ENTER, KEY_SPACE, KEY_SPACEBAR];


### PR DESCRIPTION
# Description
-  Use React.memo on DiscoverContent card to prevent re-renders
- Remove redundant useTranslation hook calls in nested components

Fixes #233
Fixes #238

