### PR TITLE
 #216 Refactor: Extract click-outside hook for reuse in dropdown components

### DIFF
--- a/apps/web/components/Feature/ExploreCreators/Hero/index.tsx
+++ b/apps/web/components/Feature/ExploreCreators/Hero/index.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";
 import { ArrowIcon } from "@/assets/icons/arrowIcon";
 import { FilterIcon } from "@/assets/icons/filterIcon";
+import { useClickOutside } from "@/hooks/useClickOutside";
 import SearchBar from "@/components/UI/SearchBar";
 import SortDropdown from "@/components/UI/SortDropdown";
 import { DEFAULT_SORT, SORT_OPTIONS } from "@/utils/sortOptions";
@@ -106,24 +107,21 @@ export default function ExploreCreatorsHero({
     categoryOptions: [...CATEGORY_OPTION_KEYS],
     formatOptions: [...FORMAT_OPTION_KEYS],
   });
+  const filterClickOutsideRefs = useMemo(
+    () => [filterButtonRef, filterOverlayRef],
+    [],
+  );
+
+  useClickOutside({
+    refs: filterClickOutsideRefs,
+    enabled: isFilterOpen,
+    handler: toggleFilter,
+  });
 
   useEffect(() => {
     if (!isFilterOpen) {
       return;
     }
-
-    const handlePointerDown = (event: MouseEvent) => {
-      const target = event.target as Node;
-
-      if (
-        filterButtonRef.current?.contains(target) ||
-        filterOverlayRef.current?.contains(target)
-      ) {
-        return;
-      }
-
-      toggleFilter();
-    };
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === KEYBOARD_KEYS.ESCAPE) {
@@ -131,11 +129,9 @@ export default function ExploreCreatorsHero({
       }
     };
 
-    document.addEventListener("mousedown", handlePointerDown);
     document.addEventListener("keydown", handleKeyDown);
 
     return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [isFilterOpen, toggleFilter]);

--- a/apps/web/components/UI/SortDropdown/index.tsx
+++ b/apps/web/components/UI/SortDropdown/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef, useEffect } from "react";
+import React, { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CREATORS } from "@/utils/translationKeys";
 import { ArrowIcon } from "@/assets/icons/arrowIcon";
@@ -11,6 +11,7 @@ import {
   SortBox,
   Text,
 } from "@/components/Feature/ExploreCreators/Hero/styles";
+import { useClickOutside } from "@/hooks/useClickOutside";
 import { MonoText } from "../Monotext";
 import { DEFAULT_SORT, SORT_OPTIONS, SortValue } from "@/utils/sortOptions";
 
@@ -32,16 +33,12 @@ export default function SortDropdown({
 
   const ref = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-
-    document.addEventListener("click", handleClickOutside);
-    return () => document.removeEventListener("click", handleClickOutside);
-  }, []);
+  useClickOutside({
+    ref,
+    enabled: open,
+    eventType: "click",
+    handler: () => setOpen(false),
+  });
 
   const handleSelect = (val: SortValue) => {
     setSelected(val);

--- a/apps/web/hooks/useClickOutside.ts
+++ b/apps/web/hooks/useClickOutside.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { RefObject, useEffect } from "react";
+
+type ClickOutsideRef = RefObject<HTMLElement | null>;
+
+type UseClickOutsideParams = {
+  ref?: ClickOutsideRef;
+  refs?: ClickOutsideRef[];
+  handler: (event: MouseEvent) => void;
+  enabled?: boolean;
+  eventType?: "mousedown" | "click";
+};
+
+export function useClickOutside({
+  ref,
+  refs,
+  handler,
+  enabled = true,
+  eventType = "mousedown",
+}: UseClickOutsideParams) {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const targetRefs = refs ?? (ref ? [ref] : []);
+
+    if (targetRefs.length === 0) {
+      return;
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target;
+
+      if (!(target instanceof Node)) {
+        return;
+      }
+
+      const isInside = targetRefs.some((targetRef) =>
+        targetRef.current?.contains(target),
+      );
+
+      if (!isInside) {
+        handler(event);
+      }
+    };
+
+    document.addEventListener(eventType, handleClickOutside);
+
+    return () => {
+      document.removeEventListener(eventType, handleClickOutside);
+    };
+  }, [enabled, eventType, handler, ref, refs]);
+}


### PR DESCRIPTION
# Description
Implemented. I extracted a reusable click-outside hook and applied it to the duplicated dropdown logic.

Fixes #216 

## Type of change
https://github.com/user-attachments/assets/923a1411-c705-43ca-8a75-e993a64d1695