### PR TITLE
#248 Fix: add missing error boundaries and error states to image components

### DIFF
--- a/apps/web/components/Feature/AboutKiibee/Hero/index.tsx
+++ b/apps/web/components/Feature/AboutKiibee/Hero/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import {
   Hero,
   Background,

--- a/apps/web/components/Feature/AboutKiibee/MorePlatform/index.tsx
+++ b/apps/web/components/Feature/AboutKiibee/MorePlatform/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import { useTranslation } from "react-i18next";
 import {
   SectionWrapper,

--- a/apps/web/components/Feature/AboutKiibee/WhatWeBelieveSection/index.tsx
+++ b/apps/web/components/Feature/AboutKiibee/WhatWeBelieveSection/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import {
   SectionWrapper,
   Container,

--- a/apps/web/components/Feature/Auth/Login/LoginForm/index.tsx
+++ b/apps/web/components/Feature/Auth/Login/LoginForm/index.tsx
@@ -16,7 +16,7 @@ import {
   ForgotLink,
 } from "./styles";
 import logo from "@/assets/icons/Kiibee_logo_mark_black.svg";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import GenericButton from "@/components/UI/GenericButton";
 import { MonoText } from "@/components/UI/Monotext";
 import { useLoginFormSchema } from "@/utils/useLoginFormSchema";

--- a/apps/web/components/Feature/Auth/Login/LoginSlide/index.tsx
+++ b/apps/web/components/Feature/Auth/Login/LoginSlide/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import {
   Dot,
   ImageStack,

--- a/apps/web/components/Feature/Auth/SignUp/index.tsx
+++ b/apps/web/components/Feature/Auth/SignUp/index.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { AUTH } from "@/utils/translationKeys";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import {
   Container,
   Inner,

--- a/apps/web/components/Feature/Auth/SignUpCreator/index.tsx
+++ b/apps/web/components/Feature/Auth/SignUpCreator/index.tsx
@@ -34,7 +34,7 @@ import {
   TernaryRow,
   TermsLink,
 } from "./styles";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import logo from "@/assets/icons/Kiibee_logo_mark_black.svg";
 import { MonoText } from "@/components/UI/Monotext";
 

--- a/apps/web/components/Feature/Auth/SignUpViewer/index.tsx
+++ b/apps/web/components/Feature/Auth/SignUpViewer/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FormEvent, useMemo, useState } from "react";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { EyeClosedIcon, EyeOpenIcon } from "@/assets/icons";

--- a/apps/web/components/Feature/CtaSection/index.tsx
+++ b/apps/web/components/Feature/CtaSection/index.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { useTranslation } from "react-i18next";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import GenericButton from "@/components/UI/GenericButton";
 import { Section, Background, Inner, Content, Title, Subtitle } from "./styles";
 import type { CtaSectionProps } from "@/types/ctaSection";

--- a/apps/web/components/Feature/ExploreCreators/TopCreators/index.tsx
+++ b/apps/web/components/Feature/ExploreCreators/TopCreators/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import { Wrapper, Header, SeeAll, List, Card, Avatar } from "./styles";
 import { creators } from "@/utils/dummyData/creators.data";
 import { MonoText } from "@/components/UI/Monotext";

--- a/apps/web/components/Feature/ForCreator/HowToGetStarted/index.tsx
+++ b/apps/web/components/Feature/ForCreator/HowToGetStarted/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import { useTranslation } from "react-i18next";
 import { CREATORS } from "@/utils/translationKeys";
 import { steps } from "@/utils/steps";

--- a/apps/web/components/Feature/ForCreator/MarketingSection/styles.ts
+++ b/apps/web/components/Feature/ForCreator/MarketingSection/styles.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import GenericButton from "@/components/UI/GenericButton";
 import { VARIANT, SIZE } from "@/utils/Constants";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import { media } from "@repo/ui/breakpoints";
 
 export const Section = styled.section`

--- a/apps/web/components/Feature/ForgetPassword/index.tsx
+++ b/apps/web/components/Feature/ForgetPassword/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FormEvent, useState } from "react";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import { useTranslation } from "react-i18next";
 import logo from "@/assets/icons/Kiibee_logo_mark_black.svg";
 import GenericButton from "@/components/UI/GenericButton";

--- a/apps/web/components/Feature/HowItWork/CustomerSection/index.tsx
+++ b/apps/web/components/Feature/HowItWork/CustomerSection/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import {
   Section,
   Inner,

--- a/apps/web/components/Feature/HowItWork/FeatureHighlights/index.tsx
+++ b/apps/web/components/Feature/HowItWork/FeatureHighlights/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import {
   Section,
   Inner,

--- a/apps/web/components/Feature/HowItWork/Hero/index.tsx
+++ b/apps/web/components/Feature/HowItWork/Hero/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import {
   Hero,
   Background,

--- a/apps/web/components/Feature/HowItWork/Steps/index.tsx
+++ b/apps/web/components/Feature/HowItWork/Steps/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import {
   StepsSection,
   Inner,

--- a/apps/web/components/Feature/SingleCollectionHero/index.tsx
+++ b/apps/web/components/Feature/SingleCollectionHero/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import {
   HeroWrapper,
   HeroContent,

--- a/apps/web/components/Feature/landing/CallToAction/index.tsx
+++ b/apps/web/components/Feature/landing/CallToAction/index.tsx
@@ -21,9 +21,9 @@ import {
 } from "./styles";
 import { desktopCards, mobileCards } from "@/utils/cards";
 import { MonoText } from "@/components/UI/Monotext";
+import SafeImage from "@/components/UI/SafeImage";
 import COLORS from "@repo/ui/colors";
 import { BUTTON, resolveImageUrl, type ImageSource } from "@/utils/Constants";
-import Image from "next/image";
 
 type CTAImageCard = {
   src: ImageSource;
@@ -71,11 +71,7 @@ export default function CallToAction() {
       <Content>
         <Brand>
           <BrandLogo>
-            <Image
-              src={resolveImageUrl(kiibeeLogo)}
-              alt={t("callToAction.logoAlt")}
-              priority
-            />
+            <SafeImage src={kiibeeLogo} alt={t("callToAction.logoAlt")} />
           </BrandLogo>
         </Brand>
         <Heading>

--- a/apps/web/components/Feature/landing/CallToAction/styles.ts
+++ b/apps/web/components/Feature/landing/CallToAction/styles.ts
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import GenericButton from "@/components/UI/GenericButton";
 import { VARIANT, SIZE } from "@/utils/Constants";
 import { media } from "@repo/ui/breakpoints";
+import SafeImage from "@/components/UI/SafeImage";
 
 export const Section = styled.section`
   position: relative;
@@ -81,7 +82,10 @@ export const MobileGrid = styled.div`
   }
 `;
 
-export const CardImage = styled.img`
+export const CardImage = styled(SafeImage).attrs({
+  fill: true,
+  sizes: "(max-width: 1024px) 50vw, 16vw",
+})`
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/apps/web/components/Feature/landing/Hero/index.tsx
+++ b/apps/web/components/Feature/landing/Hero/index.tsx
@@ -12,7 +12,7 @@ import {
   CTAWrap,
   Background,
 } from "./styles";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import hero from "@/assets/images/hero-background.webp";
 import GenericButton from "@/components/UI/GenericButton";
 import { MonoText } from "@/components/UI/Monotext";

--- a/apps/web/components/Feature/landing/SecurePayment/index.tsx
+++ b/apps/web/components/Feature/landing/SecurePayment/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import { useTranslation } from "react-i18next";
 import hero from "../../../../assets/images/mobilePay.webp";
 import creator from "../../../../assets/images/laptopMan.webp";

--- a/apps/web/components/Feature/landing/Testimonial/index.tsx
+++ b/apps/web/components/Feature/landing/Testimonial/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import { useTranslation } from "react-i18next";
 import { ArrowIcon as ArrowSvg } from "@/assets/icons/arrowIcon";
 import { Directions } from "@/utils/ui";

--- a/apps/web/components/Feature/landing/ValueStatement/index.tsx
+++ b/apps/web/components/Feature/landing/ValueStatement/index.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { Section, Inner, Content, Title, Background, Subtitle } from "./styles";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import valueBg from "@/assets/images/cta-buttom.webp";
 import GenericButton from "@/components/UI/GenericButton";
 import { MonoText } from "@/components/UI/Monotext";

--- a/apps/web/components/Feature/landing/WatchingSteps/index.tsx
+++ b/apps/web/components/Feature/landing/WatchingSteps/index.tsx
@@ -16,7 +16,7 @@ import {
   CTAWrapper,
   NumberPart,
 } from "./styles";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import { useTranslation } from "react-i18next";
 import Steps from "@/assets/images/steps.webp";
 import { MonoText } from "@/components/UI/Monotext";

--- a/apps/web/components/Layout/Footer/index.tsx
+++ b/apps/web/components/Layout/Footer/index.tsx
@@ -19,12 +19,12 @@ import {
   BottomLink,
   PaymentCardImage,
 } from "./styles";
-import Image from "next/image";
 import logo from "../../../assets/images/kiibee-logo.svg";
 import card from "../../../assets/images/card.webp";
 import { FacebookIcon, TwitterIcon, YouTubeIcon } from "@/assets/icons";
 import { footerConfig } from "@/utils/footerConfig";
 import { MonoText } from "@/components/UI/Monotext";
+import SafeImage from "@/components/UI/SafeImage";
 import COLORS from "@repo/ui/colors";
 
 const Footer = () => {
@@ -36,13 +36,7 @@ const Footer = () => {
       <Top>
         <Column>
           <LogoRow>
-            <Image
-              src={logo.src ?? logo}
-              alt={t(NAV.logoAlt)}
-              width={120}
-              height={32}
-              priority
-            />
+            <SafeImage src={logo} alt={t(NAV.logoAlt)} />
           </LogoRow>
           <IconRow>
             <FacebookIcon />

--- a/apps/web/components/Layout/Navbar/index.tsx
+++ b/apps/web/components/Layout/Navbar/index.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { NAV } from "@/utils/translationKeys";
-import Image from "next/image";
+import Image from "@/components/UI/SafeImage";
 import Link from "next/link";
 import {
   Header,
@@ -112,11 +112,15 @@ export default function NavBar() {
         </Nav>
 
         <Actions>
-          <GenericButton asAnchor href="/auth/login" variant={VARIANT.SECONDARY}>
+          <GenericButton
+            asAnchor
+            href="/auth/login"
+            variant={VARIANT.SECONDARY}
+          >
             {t(NAV.login)}
           </GenericButton>
           <GenericButton asAnchor href="/auth/signup" variant={VARIANT.PRIMARY}>
-             {t(NAV.startCreating)}
+            {t(NAV.startCreating)}
           </GenericButton>
         </Actions>
       </Inner>

--- a/apps/web/components/UI/SafeImage.tsx
+++ b/apps/web/components/UI/SafeImage.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import NextImage, { type ImageProps, type StaticImageData } from "next/image";
+import { useSafeImage } from "@/hooks/useSafeImage";
+
+type SafeImageSrc = string | StaticImageData;
+
+export const FALLBACKS = {
+  default: "/images/fallbacks/default.svg",
+  avatar: "/images/fallbacks/avatar.svg",
+  thumbnail: "/images/fallbacks/thumbnail.svg",
+  hero: "/images/fallbacks/hero.svg",
+} as const;
+
+export type SafeImageProps = Omit<ImageProps, "src"> & {
+  src: SafeImageSrc;
+  fallback?: SafeImageSrc;
+};
+
+export default function SafeImage(props: SafeImageProps) {
+  const { src } = props;
+  const imageKey = typeof src === "string" ? src : src.src;
+
+  return <SafeImageInner key={imageKey} {...props} />;
+}
+
+function SafeImageInner({
+  src,
+  fallback = FALLBACKS.default,
+  onError,
+  onLoad,
+  className,
+  style,
+  alt,
+  ...rest
+}: SafeImageProps) {
+  const { imgSrc, isError, handleError, handleLoad } = useSafeImage({
+    src,
+    fallback,
+  });
+
+  if (isError) {
+    return (
+      <span
+        role="img"
+        aria-label={
+          alt ? `Failed to load image: ${alt}` : "Failed to load image"
+        }
+        className={className}
+        style={style}
+      />
+    );
+  }
+
+  return (
+    <NextImage
+      {...rest}
+      alt={alt}
+      src={imgSrc}
+      className={className}
+      style={style}
+      onError={(event) => {
+        handleError();
+        onError?.(event);
+      }}
+      onLoad={(event) => {
+        handleLoad();
+        onLoad?.(event);
+      }}
+    />
+  );
+}

--- a/apps/web/hooks/useSafeImage.ts
+++ b/apps/web/hooks/useSafeImage.ts
@@ -1,0 +1,37 @@
+import { useCallback, useState } from "react";
+import type { StaticImageData } from "next/image";
+
+type SafeImageSrc = string | StaticImageData;
+
+interface UseSafeImageOptions {
+  src: SafeImageSrc;
+  fallback: SafeImageSrc;
+}
+
+export function useSafeImage({ src, fallback }: UseSafeImageOptions) {
+  const [imgSrc, setImgSrc] = useState<SafeImageSrc>(src);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+
+  const handleError = useCallback(() => {
+    if (imgSrc !== fallback) {
+      setImgSrc(fallback);
+      return;
+    }
+
+    setIsError(true);
+    setIsLoading(false);
+  }, [fallback, imgSrc]);
+
+  const handleLoad = useCallback(() => {
+    setIsLoading(false);
+  }, []);
+
+  return {
+    imgSrc,
+    isLoading,
+    isError,
+    handleError,
+    handleLoad,
+  };
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -4,6 +4,24 @@ const nextConfig: NextConfig = {
   compiler: {
     styledComponents: true,
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com",
+      },
+      {
+        protocol: "https",
+        hostname: "placehold.co",
+      },
+    ],
+    dangerouslyAllowSVG: true,
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+  },
 };
 
 export default nextConfig;

--- a/apps/web/public/images/fallbacks/avatar.svg
+++ b/apps/web/public/images/fallbacks/avatar.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 400 400" role="img" aria-label="Avatar placeholder">
+  <rect width="400" height="400" fill="#e5e7eb"/>
+  <circle cx="200" cy="150" r="74" fill="#cbd5e1"/>
+  <path d="M70 360c18-78 66-122 130-122s112 44 130 122H70z" fill="#94a3b8"/>
+</svg>

--- a/apps/web/public/images/fallbacks/default.svg
+++ b/apps/web/public/images/fallbacks/default.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600" viewBox="0 0 800 600" role="img" aria-label="Default placeholder">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f3f4f6"/>
+      <stop offset="100%" stop-color="#e5e7eb"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#bg)"/>
+  <rect x="250" y="190" width="300" height="220" rx="24" fill="#d1d5db"/>
+  <circle cx="350" cy="280" r="30" fill="#9ca3af"/>
+  <path d="M280 370l70-75a28 28 0 0 1 40 0l32 34 28-28a28 28 0 0 1 40 0l60 69H280z" fill="#9ca3af"/>
+</svg>

--- a/apps/web/public/images/fallbacks/hero.svg
+++ b/apps/web/public/images/fallbacks/hero.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080" viewBox="0 0 1920 1080" role="img" aria-label="Hero placeholder">
+  <defs>
+    <linearGradient id="hero" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#111827"/>
+      <stop offset="60%" stop-color="#1f2937"/>
+      <stop offset="100%" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1920" height="1080" fill="url(#hero)"/>
+  <circle cx="1560" cy="260" r="220" fill="#334155" opacity="0.45"/>
+  <circle cx="320" cy="880" r="280" fill="#1e293b" opacity="0.6"/>
+</svg>

--- a/apps/web/public/images/fallbacks/thumbnail.svg
+++ b/apps/web/public/images/fallbacks/thumbnail.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-label="Thumbnail placeholder">
+  <defs>
+    <linearGradient id="thumb" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#dbeafe"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" fill="url(#thumb)"/>
+  <rect x="92" y="66" width="456" height="228" rx="16" fill="#cbd5e1"/>
+  <circle cx="232" cy="154" r="28" fill="#94a3b8"/>
+  <path d="M160 258l92-98a20 20 0 0 1 29 0l40 43 34-33a20 20 0 0 1 29 0l96 88H160z" fill="#64748b"/>
+</svg>


### PR DESCRIPTION
# Description
I have Fix: Add missing error boundaries and error states to image components

Fixes #248 

## Type of change

<img width="1916" height="911" alt="image" src="https://github.com/user-attachments/assets/b7a621fe-55ff-4be4-92c7-282f3922aba7" />

<img width="1890" height="954" alt="image" src="https://github.com/user-attachments/assets/ba8c325b-8f53-47e6-9c4d-b88a894c2ddf" />