### PR TITLE
#232: Use memo on TutorialCard to prevent unnecessary re-renders

### DIFF
--- a/apps/web/components/Feature/TutorialVideos/TutorialCard/index.tsx
+++ b/apps/web/components/Feature/TutorialVideos/TutorialCard/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo, useMemo } from "react";
 import { resolveImageUrl, VARIANT } from "@/utils/Constants";
 import { ActionRow, VideoBox } from "./styles";
 import GenericButton from "@/components/UI/GenericButton";
@@ -30,19 +31,32 @@ const formatIconMap: Record<FormatType, IconComponent> = {
   web: WebIcon,
 };
 
-export default function TutorialCard({ tutorial }: TutorialCardProps) {
-  const imageUrl = resolveImageUrl(tutorial.image);
+function TutorialCard({ tutorial }: TutorialCardProps) {
   const { t } = useTranslation();
-  const formatType: FormatType = tutorial.formatType ?? "video";
-  const FormatIcon = formatIconMap[formatType];
-  const singleTutorialHref = `/single-tutorial?id=${tutorial.id}`;
-  const defaultButton: TutorialButton = {
-    label: t(TUTORIAL_VIDEOS.buttonFreeLabel),
-    variant: VARIANT.SECONDARY,
-    href: singleTutorialHref,
-  };
 
-  const buttons = tutorial.buttons?.length ? tutorial.buttons : [defaultButton];
+  const imageUrl = useMemo(
+    () => resolveImageUrl(tutorial.image),
+    [tutorial.image],
+  );
+
+  const FormatIcon = useMemo(() => {
+    const formatType: FormatType = tutorial.formatType ?? "video";
+    return formatIconMap[formatType];
+  }, [tutorial.formatType]);
+
+  const singleTutorialHref = useMemo(
+    () => `/single-tutorial?id=${tutorial.id}`,
+    [tutorial.id],
+  );
+
+  const buttons = useMemo(() => {
+    const defaultButton: TutorialButton = {
+      label: t(TUTORIAL_VIDEOS.buttonFreeLabel),
+      variant: VARIANT.SECONDARY,
+      href: singleTutorialHref,
+    };
+    return tutorial.buttons?.length ? tutorial.buttons : [defaultButton];
+  }, [tutorial.buttons, t, singleTutorialHref]);
 
   const resolveButtonHref = (href?: string) => {
     if (!href) return singleTutorialHref;
@@ -86,3 +100,5 @@ export default function TutorialCard({ tutorial }: TutorialCardProps) {
     </GenericCard>
   );
 }
+
+export default memo(TutorialCard);

--- a/apps/web/components/Feature/TutorialVideos/TutorialCard/index.tsx
+++ b/apps/web/components/Feature/TutorialVideos/TutorialCard/index.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { TUTORIAL_VIDEOS } from "@/utils/translationKeys";
 import type { ComponentType } from "react";
 import type { FormatType, TutorialButton, TutorialVideo } from "@/utils/types";
+import { FORMAT_TYPE } from "@/utils/types";
 import { EpubIcon, PdfIcon, VideoIcon, WebIcon } from "@/assets/icons";
 import { MonoText } from "@/components/UI/Monotext";
 import COLORS from "@repo/ui/colors";
@@ -40,7 +41,7 @@ function TutorialCard({ tutorial }: TutorialCardProps) {
   );
 
   const FormatIcon = useMemo(() => {
-    const formatType: FormatType = tutorial.formatType ?? "video";
+    const formatType: FormatType = tutorial.formatType ?? FORMAT_TYPE.VIDEO;
     return formatIconMap[formatType];
   }, [tutorial.formatType]);
 


### PR DESCRIPTION
# Description

Uses React.memo on TutorialCard to prevent unnecessary re-renders and improve rendering performance.

Fixes #232

## Type of change

Verified the optimization. Console logs confirm that TutorialCard is rendering as expected and memoization is working correctly. 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7a4389e4-b4b7-41d9-aaae-d1a2d749be26" />
 