### PR TITLE
#189: Implement settings page to content section

### DIFF
--- a/apps/web/components/Feature/Contents/AdmissionRequirements/index.tsx
+++ b/apps/web/components/Feature/Contents/AdmissionRequirements/index.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import React, { memo, useCallback, useMemo, useRef, useState } from "react";
+import { ArrowIcon } from "@/assets/icons/arrowIcon";
+import { MonoText } from "@/components/UI/Monotext";
+import { useClickOutside } from "@/hooks/useClickOutside";
+import {
+  ADMISSION_REQUIREMENTS,
+  DEFAULT_ADMISSION_REQUIREMENT,
+  AdmissionRequirementValue,
+} from "@/utils/admissionRequirements";
+import { Directions } from "@/utils/ui";
+import COLORS from "@repo/ui/colors";
+import { useTranslation } from "react-i18next";
+import {
+  AdmissionCard,
+  DropdownShell,
+  OptionButton,
+  OptionsList,
+  SelectButton,
+  TextBlock,
+} from "./styles";
+
+function AdmissionRequirements() {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<AdmissionRequirementValue>(
+    DEFAULT_ADMISSION_REQUIREMENT,
+  );
+
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useClickOutside({
+    ref: dropdownRef,
+    enabled: open,
+    eventType: "click",
+    handler: () => setOpen(false),
+  });
+
+  const selectedOption = useMemo(
+    () =>
+      ADMISSION_REQUIREMENTS.find((option) => option.value === selected) ??
+      ADMISSION_REQUIREMENTS[0],
+    [selected],
+  );
+
+  const handleSelect = useCallback((value: AdmissionRequirementValue) => {
+    setSelected(value);
+    setOpen(false);
+  }, []);
+
+  return (
+    <AdmissionCard>
+      <TextBlock>
+        <MonoText $use="Body_SemiBold">
+          {t("contents.admissionRequirements.title")}
+        </MonoText>
+
+        <MonoText $use="Body_Medium" color={COLORS.neutral.GRAY}>
+          {t("contents.admissionRequirements.description")}
+        </MonoText>
+      </TextBlock>
+
+      <DropdownShell ref={dropdownRef}>
+        <SelectButton
+          type="button"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          onClick={() => setOpen((prev) => !prev)}
+        >
+          <MonoText $use="Body_Medium">{t(selectedOption.labelKey)}</MonoText>
+          <ArrowIcon
+            color={COLORS.neutral.GRAY_400}
+            direction={open ? Directions.UP : Directions.DOWN}
+          />
+        </SelectButton>
+
+        {open && (
+          <OptionsList role="listbox">
+            {ADMISSION_REQUIREMENTS.map((option) => (
+              <OptionButton
+                key={option.value}
+                type="button"
+                role="option"
+                aria-selected={option.value === selected}
+                onClick={() => handleSelect(option.value)}
+              >
+                <MonoText $use="Body_Medium">{t(option.labelKey)}</MonoText>
+              </OptionButton>
+            ))}
+          </OptionsList>
+        )}
+      </DropdownShell>
+    </AdmissionCard>
+  );
+}
+
+export default memo(AdmissionRequirements);

--- a/apps/web/components/Feature/Contents/AdmissionRequirements/index.tsx
+++ b/apps/web/components/Feature/Contents/AdmissionRequirements/index.tsx
@@ -50,7 +50,7 @@ function AdmissionRequirements() {
   }, []);
 
   return (
-    <AdmissionCard>
+    <AdmissionCard data-test-id="admission-requirements-card">
       <TextBlock>
         <MonoText $use="Body_SemiBold">
           {t("contents.admissionRequirements.title")}
@@ -61,9 +61,13 @@ function AdmissionRequirements() {
         </MonoText>
       </TextBlock>
 
-      <DropdownShell ref={dropdownRef}>
+      <DropdownShell
+        ref={dropdownRef}
+        data-test-id="admission-requirements-dropdown"
+      >
         <SelectButton
           type="button"
+          data-test-id="admission-requirements-select-button"
           aria-haspopup="listbox"
           aria-expanded={open}
           onClick={() => setOpen((prev) => !prev)}
@@ -76,12 +80,16 @@ function AdmissionRequirements() {
         </SelectButton>
 
         {open && (
-          <OptionsList role="listbox">
+          <OptionsList
+            role="listbox"
+            data-test-id="admission-requirements-options-list"
+          >
             {ADMISSION_REQUIREMENTS.map((option) => (
               <OptionButton
                 key={option.value}
                 type="button"
                 role="option"
+                data-test-id={`admission-requirements-option-${option.value}`}
                 aria-selected={option.value === selected}
                 onClick={() => handleSelect(option.value)}
               >

--- a/apps/web/components/Feature/Contents/AdmissionRequirements/styles.ts
+++ b/apps/web/components/Feature/Contents/AdmissionRequirements/styles.ts
@@ -1,0 +1,80 @@
+import styled from "styled-components";
+
+export const AdmissionCard = styled.div`
+  width: 100%;
+  border-radius: 16px;
+  background: ${({ theme }) => theme.colors.neutral.OFF_WHITE};
+  padding: 20px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+`;
+
+export const TextBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export const DropdownShell = styled.div`
+  position: relative;
+  width: min(100%, 457px);
+`;
+
+export const SelectButton = styled.button`
+  width: 100%;
+  min-height: 45px;
+  border: 1px solid ${({ theme }) => theme.colors.primary.GRAY};
+  border-radius: 8px;
+  background: ${({ theme }) => theme.colors.primary.WHITE};
+  color: ${({ theme }) => theme.colors.primary.BLACK};
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  cursor: pointer;
+  text-align: left;
+
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  svg {
+    flex: 0 0 auto;
+  }
+`;
+
+export const OptionsList = styled.div`
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid ${({ theme }) => theme.colors.primary.GRAY};
+  border-radius: 8px;
+  background: ${({ theme }) => theme.colors.primary.WHITE};
+  box-shadow: 0 18px 32px ${({ theme }) => theme.colors.neutral.GRAY_300};
+`;
+
+export const OptionButton = styled.button`
+  width: 100%;
+  min-height: 48px;
+  border: 0;
+  background: ${({ theme }) => theme.colors.primary.WHITE};
+  color: ${({ theme }) => theme.colors.primary.BLACK};
+  padding: 0 20px;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  text-align: left;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.neutral.OFF_WHITE};
+  }
+`;

--- a/apps/web/components/Feature/Contents/AdmissionRequirements/styles.ts
+++ b/apps/web/components/Feature/Contents/AdmissionRequirements/styles.ts
@@ -7,7 +7,7 @@ export const AdmissionCard = styled.div`
   padding: 20px 16px;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 12px;
 `;
 
 export const TextBlock = styled.div`
@@ -64,7 +64,7 @@ export const OptionsList = styled.div`
 
 export const OptionButton = styled.button`
   width: 100%;
-  min-height: 48px;
+  min-height: 45px;
   border: 0;
   background: ${({ theme }) => theme.colors.primary.WHITE};
   color: ${({ theme }) => theme.colors.primary.BLACK};

--- a/apps/web/components/Feature/Contents/page.tsx
+++ b/apps/web/components/Feature/Contents/page.tsx
@@ -16,7 +16,13 @@ import {
   TabsRow,
   Title,
 } from "./styles";
-import { COLLECTIONS, CONTENT_TABS, ContentTab } from "@/utils/common";
+import {
+  COLLECTIONS,
+  CONTENT_TABS,
+  ContentTab,
+  SETTINGS,
+} from "@/utils/common";
+import AdmissionRequirements from "./AdmissionRequirements";
 
 export default function CreatorsContents() {
   const { t } = useTranslation();
@@ -53,17 +59,24 @@ export default function CreatorsContents() {
       </TabsRow>
 
       <ContentPanel>
-        <PlaceholderLine>
-          {(() => {
-            const activeItem = CONTENT_TABS.find(
-              (tab) => tab.key === activeTab,
-            );
-            if (activeItem?.descriptionKey) return t(activeItem.descriptionKey);
-            return (
-              activeItem?.description ?? t("contents.placeholders.collections")
-            );
-          })()}
-        </PlaceholderLine>
+        {activeTab === SETTINGS ? (
+          <AdmissionRequirements />
+        ) : (
+          <PlaceholderLine>
+            {(() => {
+              const activeItem = CONTENT_TABS.find(
+                (tab) => tab.key === activeTab,
+              );
+              if (activeItem?.descriptionKey) {
+                return t(activeItem.descriptionKey);
+              }
+              return (
+                activeItem?.description ??
+                t("contents.placeholders.collections")
+              );
+            })()}
+          </PlaceholderLine>
+        )}
       </ContentPanel>
     </PageShell>
   );

--- a/apps/web/locals/da.json
+++ b/apps/web/locals/da.json
@@ -855,6 +855,15 @@
       "collections": "Samlinger vil blive vist her.",
       "appearance": "Udseende vil blive vist her.",
       "settings": "Indstillinger vil blive vist her."
+    },
+    "admissionRequirements": {
+      "title": "Adgangskrav",
+      "description": "Overvej hvilken type adgang dit [contentType] skal have",
+      "options": {
+        "free": "Gratis",
+        "password": "Angiv adgangskode",
+        "email": "Anmod om e-mail"
+      }
     }
   }
 }

--- a/apps/web/locals/en.json
+++ b/apps/web/locals/en.json
@@ -850,6 +850,15 @@
       "appearance": "Appearance",
       "settings": "Settings",
       "coupons": "Coupons"
+    },
+    "admissionRequirements": {
+      "title": "Admission requirements",
+      "description": "Consider what type of access your [contentType] should have",
+      "options": {
+        "free": "Free",
+        "password": "Set password",
+        "email": "Request email"
+      }
     }
   }
 }

--- a/apps/web/utils/admissionRequirements.ts
+++ b/apps/web/utils/admissionRequirements.ts
@@ -1,0 +1,28 @@
+export const ADMISSION_REQUIREMENT_VALUES = {
+  free: "free",
+  password: "password",
+  email: "email",
+} as const;
+
+export type AdmissionRequirementValue =
+  (typeof ADMISSION_REQUIREMENT_VALUES)[keyof typeof ADMISSION_REQUIREMENT_VALUES];
+
+export const DEFAULT_ADMISSION_REQUIREMENT = ADMISSION_REQUIREMENT_VALUES.free;
+
+export const ADMISSION_REQUIREMENTS: {
+  value: AdmissionRequirementValue;
+  labelKey: string;
+}[] = [
+  {
+    value: ADMISSION_REQUIREMENT_VALUES.free,
+    labelKey: "contents.admissionRequirements.options.free",
+  },
+  {
+    value: ADMISSION_REQUIREMENT_VALUES.password,
+    labelKey: "contents.admissionRequirements.options.password",
+  },
+  {
+    value: ADMISSION_REQUIREMENT_VALUES.email,
+    labelKey: "contents.admissionRequirements.options.email",
+  },
+];

--- a/apps/web/utils/common.ts
+++ b/apps/web/utils/common.ts
@@ -1,6 +1,7 @@
 export const ALERT = "alert";
 
 export const COLLECTIONS = "collections";
+export const SETTINGS = "settings";
 
 type ContentTabItem = {
   key: ContentTab;
@@ -11,7 +12,7 @@ type ContentTabItem = {
 
 export type ContentTab = "collections" | "appearance" | "settings" | "coupons";
 
-export const CONTENT_TABS: ContentTabItem[] = [
+export const CONTENT_TABS: readonly ContentTabItem[] = [
   {
     key: "collections",
     labelKey: "contents.tabs.collections",
@@ -23,7 +24,7 @@ export const CONTENT_TABS: ContentTabItem[] = [
     descriptionKey: "Appearance content will appear here",
   },
   {
-    key: "settings",
+    key: SETTINGS,
     labelKey: "contents.tabs.settings",
     descriptionKey: "Settings content will appear here",
   },


### PR DESCRIPTION
# Description

Implements the Settings page inside the Content section.

Fixes #189 

## Type of change

<img width="1920" height="1044" alt="image" src="https://github.com/user-attachments/assets/26bd29dc-1aae-43a3-bd24-59693d2fea6a" />
 
<img width="1920" height="1048" alt="image" src="https://github.com/user-attachments/assets/cf986ddb-5e67-4099-ae23-4bacd476a789" />


