### PR TITLE
#355: Create coupon modal on content section

### DIFF
--- a/apps/web/components/Feature/Contents/ContentsHeaderAction.tsx
+++ b/apps/web/components/Feature/Contents/ContentsHeaderAction.tsx
@@ -66,7 +66,7 @@ export default function ContentsHeaderAction({
 
   if (activeTab === COUPONS) {
     return (
-      <CreateButton type="button" onClick={onCreateCoupon ?? onCreate}>
+      <CreateButton type="button" onClick={onCreateCoupon}>
         <PlusIcon width={16} height={16} color={COLORS.primary.WHITE} />
         <MonoText $use="Body_Medium" color="inherit">
           {t("contents.actions.createCoupon")}

--- a/apps/web/components/Feature/Contents/ContentsHeaderAction.tsx
+++ b/apps/web/components/Feature/Contents/ContentsHeaderAction.tsx
@@ -23,6 +23,7 @@ type Props = {
   activeTab: ContentTab;
   onCreate: () => void;
   onCancel: () => void;
+  onCreateCoupon?: () => void;
   onSave: () => void;
 };
 
@@ -30,6 +31,7 @@ export default function ContentsHeaderAction({
   activeTab,
   onCreate,
   onCancel,
+  onCreateCoupon,
   onSave,
 }: Props) {
   const { t } = useTranslation();
@@ -64,7 +66,7 @@ export default function ContentsHeaderAction({
 
   if (activeTab === COUPONS) {
     return (
-      <CreateButton type="button" onClick={onCreate}>
+      <CreateButton type="button" onClick={onCreateCoupon ?? onCreate}>
         <PlusIcon width={16} height={16} color={COLORS.primary.WHITE} />
         <MonoText $use="Body_Medium" color="inherit">
           {t("contents.actions.createCoupon")}

--- a/apps/web/components/Feature/Contents/CouponDetailsModal.styles.ts
+++ b/apps/web/components/Feature/Contents/CouponDetailsModal.styles.ts
@@ -66,7 +66,6 @@ export const SectionTitle = styled(MonoText).attrs({
   $use: "Body_Medium",
 })`
   color: ${COLORS.primary.BLACK};
-  font-weight: 600;
   margin-top: 6px;
 `;
 

--- a/apps/web/components/Feature/Contents/CouponDetailsModal.styles.ts
+++ b/apps/web/components/Feature/Contents/CouponDetailsModal.styles.ts
@@ -1,0 +1,134 @@
+import styled from "styled-components";
+import { typography } from "@repo/ui/typography";
+import COLORS from "@repo/ui/colors";
+import { MonoText } from "@/components/UI/Monotext";
+import { media } from "@repo/ui/breakpoints";
+
+export const ModalContent = styled.div`
+  display: flex;
+  min-height: 380px;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 45px;
+
+  ${media.tablet} {
+    min-height: auto;
+    padding-top: 28px;
+    padding-bottom: 28px;
+  }
+`;
+
+export const BackButton = styled.button`
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const FormShell = styled.form`
+  width: min(457px, 100%);
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  text-align: left;
+`;
+
+export const ModalTitle = styled(MonoText).attrs({
+  $use: "H4_Medium",
+})`
+  color: ${COLORS.primary.BLACK};
+  text-align: center;
+  margin-bottom: 12px;
+  padding-top: 20px;
+`;
+
+export const FieldGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export const FieldLabel = styled.label`
+  ${typography.Body_Medium};
+  color: ${COLORS.primary.BLACK};
+`;
+
+export const SectionTitle = styled(MonoText).attrs({
+  $use: "Body_Medium",
+})`
+  color: ${COLORS.primary.BLACK};
+  font-weight: 600;
+  margin-top: 6px;
+`;
+
+export const HelperText = styled(MonoText).attrs({
+  $use: "Body_Medium",
+})`
+  color: ${COLORS.neutral.GRAY};
+`;
+
+export const CouponInput = styled.input`
+  width: 100%;
+  height: 40px;
+  border: 1px solid ${COLORS.neutral.GRAY_300};
+  border-radius: 10px;
+  background: ${COLORS.neutral.GRAY_200};
+  padding: 0 16px;
+  color: ${COLORS.primary.BLACK};
+  ${typography.Body_Medium};
+  outline: none;
+
+  &::placeholder {
+    color: ${COLORS.neutral.GRAY_400};
+  }
+
+  &:focus {
+    border-color: ${COLORS.primary.BLACK};
+    background: ${COLORS.primary.WHITE};
+  }
+`;
+
+export const SelectButton = styled.button`
+  width: 100%;
+  height: 44px;
+  border: 1px solid ${COLORS.neutral.GRAY_300};
+  border-radius: 8px;
+  background: ${COLORS.primary.WHITE};
+  padding: 0 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: ${COLORS.primary.BLACK};
+  cursor: pointer;
+  ${typography.Body_Medium};
+`;
+
+export const NextButton = styled.button`
+  align-self: center;
+  width: min(310px, 100%);
+  height: 38px;
+  border: 0;
+  border-radius: 8px;
+  background: ${COLORS.neutral.GRAY};
+  color: ${COLORS.primary.WHITE};
+  margin-top: 14px;
+  cursor: pointer;
+  ${typography.Body_Bold};
+
+  &:not(:disabled) {
+    background: ${COLORS.primary.BLACK};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+`;

--- a/apps/web/components/Feature/Contents/CouponDetailsModal.styles.ts
+++ b/apps/web/components/Feature/Contents/CouponDetailsModal.styles.ts
@@ -97,21 +97,6 @@ export const CouponInput = styled.input`
   }
 `;
 
-export const SelectButton = styled.button`
-  width: 100%;
-  height: 44px;
-  border: 1px solid ${COLORS.neutral.GRAY_300};
-  border-radius: 8px;
-  background: ${COLORS.primary.WHITE};
-  padding: 0 16px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  color: ${COLORS.primary.BLACK};
-  cursor: pointer;
-  ${typography.Body_Medium};
-`;
-
 export const NextButton = styled.button`
   align-self: center;
   width: min(310px, 100%);

--- a/apps/web/components/Feature/Contents/CouponDetailsModal.tsx
+++ b/apps/web/components/Feature/Contents/CouponDetailsModal.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import React, { useId, useState } from "react";
+import React, { useId, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ArrowIcon, BackButtonIcon } from "@/assets/icons";
+import { BackButtonIcon } from "@/assets/icons";
 import { GenericModal } from "@/components/UI/Modals";
-import COLORS from "@repo/ui/colors";
-import { Directions } from "@/utils/ui";
+import DropdownField from "@/components/UI/InputFields/DropdownField";
 import {
   CouponInput,
   BackButton,
@@ -17,7 +16,6 @@ import {
   ModalTitle,
   NextButton,
   SectionTitle,
-  SelectButton,
 } from "./CouponDetailsModal.styles";
 
 type CouponDetailsModalProps = {
@@ -34,6 +32,20 @@ export default function CouponDetailsModal({
   const discountId = useId();
   const [title, setTitle] = useState("");
   const [discountValue, setDiscountValue] = useState("");
+  const [discountType, setDiscountType] = useState("fixedAmount");
+  const discountTypeOptions = useMemo(
+    () => [
+      {
+        value: "fixedAmount",
+        label: t("contents.couponDetails.discountType.fixedAmount"),
+      },
+      {
+        value: "percentage",
+        label: t("contents.couponDetails.discountType.percentage"),
+      },
+    ],
+    [t],
+  );
 
   const canContinue =
     title.trim().length > 0 && discountValue.trim().length > 0;
@@ -79,15 +91,11 @@ export default function CouponDetailsModal({
           </SectionTitle>
           <HelperText>{t("contents.couponDetails.discountHelp")}</HelperText>
 
-          <SelectButton type="button" aria-haspopup="listbox">
-            <span>{t("contents.couponDetails.discountType.fixedAmount")}</span>
-            <ArrowIcon
-              width={8}
-              height={5}
-              color={COLORS.neutral.GRAY}
-              direction={Directions.RIGHT}
-            />
-          </SelectButton>
+          <DropdownField
+            options={discountTypeOptions}
+            value={discountType}
+            onChange={setDiscountType}
+          />
 
           <CouponInput
             id={discountId}

--- a/apps/web/components/Feature/Contents/CouponDetailsModal.tsx
+++ b/apps/web/components/Feature/Contents/CouponDetailsModal.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import React, { useId, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ArrowIcon, BackButtonIcon } from "@/assets/icons";
+import { GenericModal } from "@/components/UI/Modals";
+import COLORS from "@repo/ui/colors";
+import { Directions } from "@/utils/ui";
+import {
+  CouponInput,
+  BackButton,
+  FieldGroup,
+  FieldLabel,
+  FormShell,
+  HelperText,
+  ModalContent,
+  ModalTitle,
+  NextButton,
+  SectionTitle,
+  SelectButton,
+} from "./CouponDetailsModal.styles";
+
+type CouponDetailsModalProps = {
+  visible: boolean;
+  onClose: () => void;
+};
+
+export default function CouponDetailsModal({
+  visible,
+  onClose,
+}: CouponDetailsModalProps) {
+  const { t } = useTranslation();
+  const titleId = useId();
+  const discountId = useId();
+  const [title, setTitle] = useState("");
+  const [discountValue, setDiscountValue] = useState("");
+
+  const canContinue =
+    title.trim().length > 0 && discountValue.trim().length > 0;
+
+  return (
+    <GenericModal
+      visible={visible}
+      onClose={onClose}
+      width="670px"
+      height="480px"
+      padding="20px"
+      borderRadius="20px"
+    >
+      <ModalContent>
+        <BackButton
+          type="button"
+          aria-label={t("common.back")}
+          onClick={onClose}
+        >
+          <BackButtonIcon size={28} strokeWidth={2.5} />
+        </BackButton>
+
+        <FormShell onSubmit={(event) => event.preventDefault()}>
+          <ModalTitle id="coupon-details-title">
+            {t("contents.couponDetails.title")}
+          </ModalTitle>
+
+          <FieldGroup>
+            <FieldLabel htmlFor={titleId}>
+              {t("contents.couponDetails.fields.title")}
+            </FieldLabel>
+            <CouponInput
+              id={titleId}
+              type="text"
+              value={title}
+              placeholder={t("contents.couponDetails.placeholders.title")}
+              onChange={(event) => setTitle(event.target.value)}
+            />
+          </FieldGroup>
+
+          <SectionTitle>
+            {t("contents.couponDetails.discountValue")}
+          </SectionTitle>
+          <HelperText>{t("contents.couponDetails.discountHelp")}</HelperText>
+
+          <SelectButton type="button" aria-haspopup="listbox">
+            <span>{t("contents.couponDetails.discountType.fixedAmount")}</span>
+            <ArrowIcon
+              width={8}
+              height={5}
+              color={COLORS.neutral.GRAY}
+              direction={Directions.RIGHT}
+            />
+          </SelectButton>
+
+          <CouponInput
+            id={discountId}
+            type="text"
+            inputMode="decimal"
+            value={discountValue}
+            placeholder={t(
+              "contents.couponDetails.placeholders.discountAmount",
+            )}
+            onChange={(event) => setDiscountValue(event.target.value)}
+          />
+
+          <NextButton type="submit" disabled={!canContinue}>
+            {t("common.next")}
+          </NextButton>
+        </FormShell>
+      </ModalContent>
+    </GenericModal>
+  );
+}

--- a/apps/web/components/Feature/Contents/CouponDetailsModal.tsx
+++ b/apps/web/components/Feature/Contents/CouponDetailsModal.tsx
@@ -6,6 +6,11 @@ import { BackButtonIcon } from "@/assets/icons";
 import { GenericModal } from "@/components/UI/Modals";
 import DropdownField from "@/components/UI/InputFields/DropdownField";
 import {
+  COUPON_DISCOUNT_FIXED_AMOUNT,
+  COUPON_DISCOUNT_PERCENTAGE,
+  type CouponDiscountType,
+} from "@/utils/common";
+import {
   CouponInput,
   BackButton,
   FieldGroup,
@@ -32,15 +37,17 @@ export default function CouponDetailsModal({
   const discountId = useId();
   const [title, setTitle] = useState("");
   const [discountValue, setDiscountValue] = useState("");
-  const [discountType, setDiscountType] = useState("fixedAmount");
+  const [discountType, setDiscountType] = useState<CouponDiscountType>(
+    COUPON_DISCOUNT_FIXED_AMOUNT,
+  );
   const discountTypeOptions = useMemo(
     () => [
       {
-        value: "fixedAmount",
+        value: COUPON_DISCOUNT_FIXED_AMOUNT,
         label: t("contents.couponDetails.discountType.fixedAmount"),
       },
       {
-        value: "percentage",
+        value: COUPON_DISCOUNT_PERCENTAGE,
         label: t("contents.couponDetails.discountType.percentage"),
       },
     ],
@@ -94,7 +101,7 @@ export default function CouponDetailsModal({
           <DropdownField
             options={discountTypeOptions}
             value={discountType}
-            onChange={setDiscountType}
+            onChange={(value) => setDiscountType(value as CouponDiscountType)}
           />
 
           <CouponInput
@@ -103,7 +110,7 @@ export default function CouponDetailsModal({
             inputMode="decimal"
             value={discountValue}
             placeholder={t(
-              discountType === "percentage"
+              discountType === COUPON_DISCOUNT_PERCENTAGE
                 ? "contents.couponDetails.placeholders.discountPercentage"
                 : "contents.couponDetails.placeholders.discountAmount",
             )}

--- a/apps/web/components/Feature/Contents/CouponDetailsModal.tsx
+++ b/apps/web/components/Feature/Contents/CouponDetailsModal.tsx
@@ -103,7 +103,9 @@ export default function CouponDetailsModal({
             inputMode="decimal"
             value={discountValue}
             placeholder={t(
-              "contents.couponDetails.placeholders.discountAmount",
+              discountType === "percentage"
+                ? "contents.couponDetails.placeholders.discountPercentage"
+                : "contents.couponDetails.placeholders.discountAmount",
             )}
             onChange={(event) => setDiscountValue(event.target.value)}
           />

--- a/apps/web/components/Feature/Contents/page.tsx
+++ b/apps/web/components/Feature/Contents/page.tsx
@@ -31,6 +31,7 @@ import { SuccessArcIcon } from "@/assets/icons";
 import { MODAL_ALIGN } from "@/utils/ui";
 import { INPUT_VARIANTS } from "@/utils/Constants";
 import ContentsHeaderAction from "./ContentsHeaderAction";
+import CouponDetailsModal from "./CouponDetailsModal";
 
 export default function CreatorsContents() {
   const { t } = useTranslation();
@@ -40,10 +41,13 @@ export default function CreatorsContents() {
   const [showContentTypeModal, setShowContentTypeModal] = useState(false);
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [collectionName, setCollectionName] = useState("");
+  const [showCouponDetails, setShowCouponDetails] = useState(false);
+  const handleCancel = () => {};
+  const handleSave = () => {};
   const handleCreateClick = () => {
     switch (activeTab) {
       case COUPONS:
-        setShowContentTypeModal(true);
+        setShowCouponDetails(true);
         break;
 
       case COLLECTIONS:
@@ -69,8 +73,9 @@ export default function CreatorsContents() {
         <ContentsHeaderAction
           activeTab={activeTab}
           onCreate={handleCreateClick}
-          onCancel={() => {}}
-          onSave={() => {}}
+          onCancel={handleCancel}
+          onCreateCoupon={() => setShowCouponDetails(true)}
+          onSave={handleSave}
         />
       </PageHeader>
 
@@ -169,6 +174,11 @@ export default function CreatorsContents() {
         width="480px"
         padding="40px 30px"
         showCloseButton={false}
+      />
+
+      <CouponDetailsModal
+        visible={showCouponDetails}
+        onClose={() => setShowCouponDetails(false)}
       />
     </PageShell>
   );

--- a/apps/web/components/Feature/Contents/page.tsx
+++ b/apps/web/components/Feature/Contents/page.tsx
@@ -44,8 +44,6 @@ export default function CreatorsContents() {
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [collectionName, setCollectionName] = useState("");
   const [showCouponDetails, setShowCouponDetails] = useState(false);
-  const handleCancel = () => {};
-  const handleSave = () => {};
   const handleCreateClick = () => {
     switch (activeTab) {
       case COUPONS:
@@ -76,9 +74,9 @@ export default function CreatorsContents() {
         <ContentsHeaderAction
           activeTab={activeTab}
           onCreate={handleCreateClick}
-          onCancel={handleCancel}
+          onCancel={() => {}}
           onCreateCoupon={() => setShowCouponDetails(true)}
-          onSave={handleSave}
+          onSave={() => {}}
         />
       </PageHeader>
 

--- a/apps/web/components/UI/Modals/styles.ts
+++ b/apps/web/components/UI/Modals/styles.ts
@@ -32,7 +32,7 @@ export const ModalContainer = styled.div<{
 
   ${media.tablet} {
     width: 90%;
-    padding: 32px 24px;
+    padding: ${({ $padding }) => $padding || "32px 24px"};
   }
 `;
 

--- a/apps/web/locals/da.json
+++ b/apps/web/locals/da.json
@@ -903,6 +903,7 @@
     "title": "Indhold",
     "actions": {
       "createCollection": "Opret samling",
+      "createCoupon": "Opret kupon",
       "search": "Sog indhold",
       "cancel": "Annuller",
       "save": "Gem",

--- a/apps/web/locals/da.json
+++ b/apps/web/locals/da.json
@@ -702,6 +702,8 @@
     "optional": "valgfrit",
     "save": "Save",
     "cancel": "Cancel",
+    "back": "Tilbage",
+    "close": "Luk",
     "previous": "Forrige",
     "next": "Næste"
   },
@@ -918,6 +920,21 @@
       "createCoupon": "Opret kupon",
       "search": "Sog indhold",
       "deleteContent": "Delete content"
+    },
+    "couponDetails": {
+      "title": "Kupondetaljer",
+      "fields": {
+        "title": "Titel"
+      },
+      "placeholders": {
+        "title": "Indtast kort titel",
+        "discountAmount": "Indtast rabatbeloeb"
+      },
+      "discountValue": "Rabatvaerdi",
+      "discountHelp": "Indtast det rabatbeloeb eller den procentdel, du vil tilbyde.",
+      "discountType": {
+        "fixedAmount": "Fast beloeb"
+      }
     },
     "tabs": {
       "collections": "Samlinger",

--- a/apps/web/locals/da.json
+++ b/apps/web/locals/da.json
@@ -933,7 +933,8 @@
       "discountValue": "Rabatvaerdi",
       "discountHelp": "Indtast det rabatbeloeb eller den procentdel, du vil tilbyde.",
       "discountType": {
-        "fixedAmount": "Fast beloeb"
+        "fixedAmount": "Fast beloeb",
+        "percentage": "Procent"
       }
     },
     "tabs": {

--- a/apps/web/locals/da.json
+++ b/apps/web/locals/da.json
@@ -916,7 +916,8 @@
       },
       "placeholders": {
         "title": "Indtast kort titel",
-        "discountAmount": "Indtast rabatbeloeb"
+        "discountAmount": "Indtast rabatbeloeb",
+        "discountPercentage": "Indtast rabatprocent"
       },
       "discountValue": "Rabatvaerdi",
       "discountHelp": "Indtast det rabatbeloeb eller den procentdel, du vil tilbyde.",

--- a/apps/web/locals/en.json
+++ b/apps/web/locals/en.json
@@ -916,7 +916,8 @@
       },
       "placeholders": {
         "title": "Enter short title",
-        "discountAmount": "Enter discount amount"
+        "discountAmount": "Enter discount amount",
+        "discountPercentage": "Enter discount percentage"
       },
       "discountValue": "Discount Value",
       "discountHelp": "Enter the discount amount or percentage you want to offer.",

--- a/apps/web/locals/en.json
+++ b/apps/web/locals/en.json
@@ -932,7 +932,8 @@
       "discountValue": "Discount Value",
       "discountHelp": "Enter the discount amount or percentage you want to offer.",
       "discountType": {
-        "fixedAmount": "Fixed amount"
+        "fixedAmount": "Fixed amount",
+        "percentage": "Percentage"
       }
     },
     "tabs": {

--- a/apps/web/locals/en.json
+++ b/apps/web/locals/en.json
@@ -702,6 +702,8 @@
     "optional": "optional",
     "save": "Save",
     "cancel": "Cancel",
+    "back": "Back",
+    "close": "Close",
     "previous": "Previous",
     "next": "Next"
   },
@@ -917,6 +919,21 @@
       "createCoupon": "Create coupon",
       "search": "Search contents",
       "deleteContent": "Delete content"
+    },
+    "couponDetails": {
+      "title": "Coupon details",
+      "fields": {
+        "title": "Title"
+      },
+      "placeholders": {
+        "title": "Enter short title",
+        "discountAmount": "Enter discount amount"
+      },
+      "discountValue": "Discount Value",
+      "discountHelp": "Enter the discount amount or percentage you want to offer.",
+      "discountType": {
+        "fixedAmount": "Fixed amount"
+      }
     },
     "tabs": {
       "collections": "Collections",

--- a/apps/web/locals/en.json
+++ b/apps/web/locals/en.json
@@ -903,6 +903,7 @@
     "title": "Contents",
     "actions": {
       "createCollection": "Create collection",
+      "createCoupon": "Create coupon",
       "search": "Search contents",
       "cancel": "Cancel",
       "save": "Save",

--- a/apps/web/utils/common.ts
+++ b/apps/web/utils/common.ts
@@ -4,6 +4,8 @@ export const COLLECTIONS = "collections";
 export const APPEARANCE = "appearance";
 export const SETTINGS = "settings";
 export const COUPONS = "coupons";
+export const COUPON_DISCOUNT_FIXED_AMOUNT = "fixedAmount";
+export const COUPON_DISCOUNT_PERCENTAGE = "percentage";
 
 type ContentTabItem = {
   key: ContentTab;
@@ -13,6 +15,7 @@ type ContentTabItem = {
 };
 
 export type ContentTab = "collections" | "appearance" | "settings" | "coupons";
+export type CouponDiscountType = "fixedAmount" | "percentage";
 
 export const CONTENT_TABS: readonly ContentTabItem[] = [
   {


### PR DESCRIPTION
# Description

Adds a create coupon modal to the content section for managing coupon creation.

Closes #355

## Type of change

<img width="1920" height="1039" alt="image" src="https://github.com/user-attachments/assets/d9b9c0eb-c0b3-4296-8f6b-46a1b298fc01" />

[screen-capture (6).webm](https://github.com/user-attachments/assets/fe84d308-2b15-4d4b-b367-5fe2688ad77f)


