### PR TITLE
482: BUGS: No token-refresh or 401 handling — expired sessions leave the user stuck

### DIFF
--- a/apps/web/components/Feature/Auth/SignUpViewer/index.tsx
+++ b/apps/web/components/Feature/Auth/SignUpViewer/index.tsx
@@ -11,6 +11,7 @@ import GenericButton from "@/components/UI/GenericButton";
 import InputField from "@/components/UI/InputFields";
 import { MonoText } from "@/components/UI/Monotext";
 import { useViewerSignUp } from "@/hooks/auth/useViewerSignUp";
+import { persistAuthSession } from "@/lib/auth/authSession";
 import { normalizeApiError } from "@/lib/http/errors/apiError";
 import { ALERT } from "@/utils/common";
 import { PATHS } from "@/utils/path";
@@ -97,15 +98,7 @@ export default function SignUpViewer() {
         confirmPassword: formValues.repeatPassword,
       });
 
-      const { accessToken, refreshToken } = response.data ?? {};
-
-      if (accessToken) {
-        window.localStorage.setItem("kiibee.accessToken", accessToken);
-      }
-
-      if (refreshToken) {
-        window.localStorage.setItem("kiibee.refreshToken", refreshToken);
-      }
+      persistAuthSession(response);
 
       router.push("/auth/signup-viewer/preferences");
     } catch (error) {

--- a/apps/web/components/Feature/Dashboard/ClientDashboardCreators.tsx
+++ b/apps/web/components/Feature/Dashboard/ClientDashboardCreators.tsx
@@ -15,6 +15,7 @@ import { GenericModal } from "@/components/UI/Modals";
 import { MonoText } from "@/components/UI/Monotext";
 import { creatorProfileData } from "@/utils/dummyData/profile.data";
 import { useTranslation } from "react-i18next";
+import { clearAuthSession } from "@/lib/auth/authSession";
 import { PATHS } from "@/utils/path";
 import UsersContent from "../Users/UsersContent";
 
@@ -53,7 +54,8 @@ export default function ClientDashboardCreators() {
 
   const handleConfirmLogout = useCallback(() => {
     setShowLogoutModal(false);
-    router.push(PATHS.AUTH_LOGIN);
+    clearAuthSession();
+    router.replace(PATHS.AUTH_LOGIN);
   }, [router]);
 
   const renderHeader = () => {

--- a/apps/web/hooks/auth/useLogin.ts
+++ b/apps/web/hooks/auth/useLogin.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { API } from "@/lib/http/api/endpoints";
+import { persistAuthSession } from "@/lib/auth/authSession";
 import { usePostAPI } from "@/lib/http/api/postApi";
 import { PATHS } from "@/utils/path";
 
@@ -35,38 +36,12 @@ export type LoginUser = {
   [key: string]: unknown;
 };
 
-const ACCESS_TOKEN_KEY = "kiibee.accessToken";
-const REFRESH_TOKEN_KEY = "kiibee.refreshToken";
-const USER_KEY = "kiibee.user";
 const USER_ROLES = {
   VIEWER: "viewer",
 } as const;
 
-export const persistLoginSession = (response: LoginResponse) => {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  const accessToken =
-    response.accessToken ??
-    response.token ??
-    response.data?.accessToken ??
-    response.data?.token;
-  const refreshToken = response.refreshToken ?? response.data?.refreshToken;
-  const user = response.user ?? response.data?.user;
-
-  if (accessToken) {
-    window.localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
-  }
-
-  if (refreshToken) {
-    window.localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
-  }
-
-  if (user) {
-    window.localStorage.setItem(USER_KEY, JSON.stringify(user));
-  }
-};
+export const persistLoginSession = (response: LoginResponse) =>
+  persistAuthSession(response);
 
 export const getPostLoginPath = (response: LoginResponse) => {
   const user = (response.user ?? response.data?.user) as LoginUser | undefined;

--- a/apps/web/lib/auth/authSession.ts
+++ b/apps/web/lib/auth/authSession.ts
@@ -1,0 +1,64 @@
+type AuthSessionPayload = {
+  accessToken?: string;
+  refreshToken?: string;
+  token?: string;
+  user?: unknown;
+  data?: {
+    accessToken?: string;
+    refreshToken?: string;
+    token?: string;
+    user?: unknown;
+  };
+};
+
+export const AUTH_STORAGE_KEYS = {
+  accessToken: "kiibee.accessToken",
+  refreshToken: "kiibee.refreshToken",
+  user: "kiibee.user",
+} as const;
+
+const isBrowser = () => typeof window !== "undefined";
+
+export const getAccessToken = () => {
+  if (!isBrowser()) return null;
+  return window.localStorage.getItem(AUTH_STORAGE_KEYS.accessToken);
+};
+
+export const getRefreshToken = () => {
+  if (!isBrowser()) return null;
+  return window.localStorage.getItem(AUTH_STORAGE_KEYS.refreshToken);
+};
+
+export const clearAuthSession = () => {
+  if (!isBrowser()) return;
+
+  window.localStorage.removeItem(AUTH_STORAGE_KEYS.accessToken);
+  window.localStorage.removeItem(AUTH_STORAGE_KEYS.refreshToken);
+  window.localStorage.removeItem(AUTH_STORAGE_KEYS.user);
+};
+
+export const persistAuthSession = (payload: AuthSessionPayload) => {
+  if (!isBrowser()) return null;
+
+  const accessToken =
+    payload.accessToken ??
+    payload.token ??
+    payload.data?.accessToken ??
+    payload.data?.token;
+  const refreshToken = payload.refreshToken ?? payload.data?.refreshToken;
+  const user = payload.user ?? payload.data?.user;
+
+  if (accessToken) {
+    window.localStorage.setItem(AUTH_STORAGE_KEYS.accessToken, accessToken);
+  }
+
+  if (refreshToken) {
+    window.localStorage.setItem(AUTH_STORAGE_KEYS.refreshToken, refreshToken);
+  }
+
+  if (user) {
+    window.localStorage.setItem(AUTH_STORAGE_KEYS.user, JSON.stringify(user));
+  }
+
+  return accessToken ?? null;
+};

--- a/apps/web/lib/http/interceptors/request.interceptor.ts
+++ b/apps/web/lib/http/interceptors/request.interceptor.ts
@@ -1,18 +1,14 @@
 import type { AxiosInstance, InternalAxiosRequestConfig } from "axios";
-
-const getAccessToken = () => {
-  if (typeof window === "undefined") {
-    return null;
-  }
-
-  return window.localStorage.getItem("kiibee.accessToken");
-};
+import { API } from "@/lib/http/api/endpoints";
+import { getAccessToken } from "@/lib/auth/authSession";
 
 export const attachRequestInterceptor = (client: AxiosInstance) => {
   client.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+    const requestUrl = config.url ?? "";
+    const isRefreshRequest = requestUrl.includes(API.auth.refresh);
     const token = getAccessToken();
 
-    if (token) {
+    if (token && !isRefreshRequest) {
       config.headers.Authorization = `Bearer ${token}`;
     }
 

--- a/apps/web/lib/http/interceptors/response.interceptor.ts
+++ b/apps/web/lib/http/interceptors/response.interceptor.ts
@@ -1,9 +1,115 @@
-import type { AxiosInstance } from "axios";
+import axios, {
+  type AxiosInstance,
+  type InternalAxiosRequestConfig,
+  type AxiosResponse,
+} from "axios";
+import {
+  clearAuthSession,
+  getRefreshToken,
+  persistAuthSession,
+} from "@/lib/auth/authSession";
+import { API } from "@/lib/http/api/endpoints";
 import { normalizeApiError } from "@/lib/http/errors/apiError";
+import { PATHS } from "@/utils/path";
+import { HTTP_STATUS_UNAUTHORIZED } from "@/utils/Constants";
+
+type RefreshResponse = {
+  accessToken?: string;
+  refreshToken?: string;
+  token?: string;
+  data?: {
+    accessToken?: string;
+    refreshToken?: string;
+    token?: string;
+  };
+};
+
+type RetriableRequestConfig = InternalAxiosRequestConfig & {
+  _retry?: boolean;
+};
+
+let refreshPromise: Promise<string | null> | null = null;
+
+const clearSessionAndRedirectToLogin = () => {
+  if (typeof window === "undefined") return;
+
+  clearAuthSession();
+
+  if (window.location.pathname !== PATHS.AUTH_LOGIN) {
+    window.location.replace(PATHS.AUTH_LOGIN);
+  }
+};
+
+const refreshAccessToken = async (
+  client: AxiosInstance,
+): Promise<string | null> => {
+  if (!refreshPromise) {
+    const refreshToken = getRefreshToken();
+
+    if (!refreshToken) {
+      return Promise.reject(new Error("Missing refresh token"));
+    }
+
+    refreshPromise = client
+      .post<RefreshResponse>(API.auth.refresh, { refreshToken })
+      .then((response: AxiosResponse<RefreshResponse>) => {
+        const nextAccessToken = persistAuthSession(response.data);
+
+        if (!nextAccessToken) {
+          throw new Error("Refresh response missing access token");
+        }
+
+        return nextAccessToken;
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+
+  return refreshPromise;
+};
 
 export const attachResponseInterceptor = (client: AxiosInstance) => {
   client.interceptors.response.use(
     (response) => response,
-    (error) => Promise.reject(normalizeApiError(error)),
+    async (error) => {
+      if (!axios.isAxiosError(error)) {
+        return Promise.reject(normalizeApiError(error));
+      }
+
+      const status = error.response?.status;
+      const originalRequest = error.config as
+        | RetriableRequestConfig
+        | undefined;
+      const requestUrl = originalRequest?.url ?? "";
+      const isRefreshRequest = requestUrl.includes(API.auth.refresh);
+
+      if (
+        status !== HTTP_STATUS_UNAUTHORIZED ||
+        !originalRequest ||
+        originalRequest._retry ||
+        isRefreshRequest
+      ) {
+        return Promise.reject(normalizeApiError(error));
+      }
+
+      originalRequest._retry = true;
+
+      try {
+        const refreshedAccessToken = await refreshAccessToken(client);
+
+        if (!refreshedAccessToken) {
+          throw new Error("Unable to refresh access token");
+        }
+
+        originalRequest.headers = originalRequest.headers ?? {};
+        originalRequest.headers.Authorization = `Bearer ${refreshedAccessToken}`;
+
+        return client(originalRequest);
+      } catch {
+        clearSessionAndRedirectToLogin();
+        return Promise.reject(normalizeApiError(error));
+      }
+    },
   );
 };

--- a/apps/web/utils/Constants.ts
+++ b/apps/web/utils/Constants.ts
@@ -85,3 +85,4 @@ export const SUBSCRIPTION_STEP = {
 export const maxReceiptCharacters = 200;
 export const maxDescriptionCharacters = 500;
 export const maxLogoNameCharacters = 100;
+export const HTTP_STATUS_UNAUTHORIZED = 401;


### PR DESCRIPTION
# Description
- On 401, the app now auto-refreshes the token and retries the failed request.
- If many requests fail with 401 together, only one refresh call runs (others wait).
- If refresh fails, session is cleared and user is redirected to login.

Fixes #482
