### PR TITLE
#449: Viewer Dashboard—Previously rented page UI

### DIFF
--- a/apps/web/components/Feature/Dashboard/ClientDashboardViewer.tsx
+++ b/apps/web/components/Feature/Dashboard/ClientDashboardViewer.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/utils/SidebarItems";
 import { MonoText } from "@/components/UI/Monotext";
 import PurchasedContent from "@/components/Feature/Dashboard/ClientViewerPurchased/PurchasedContent";
+import PreviouslyRentedContent from "@/components/Feature/Dashboard/ClientViewerPurchased/PreviouslyRentedContent";
 
 const ROUTABLE_VIEWER_VIEWS = new Set<string>([
   VIEWER_VIEW_VALUES.PURCHASED,
@@ -85,7 +86,12 @@ export default function ClientDashboardViewer() {
   return (
     <DashboardLayout
       header={<ViewerDashboardHeader onToggleSidebar={toggleSidebar} />}
-      contentPadding={activePage === VIEWER_LABELS.PURCHASED ? "0" : undefined}
+      contentPadding={
+        activePage === VIEWER_LABELS.PURCHASED ||
+        activePage === VIEWER_LABELS.PREVIOUSLY_RENTED
+          ? "0"
+          : undefined
+      }
       sidebar={
         <Sidebar
           open={open}
@@ -99,6 +105,8 @@ export default function ClientDashboardViewer() {
     >
       {activePage === VIEWER_LABELS.PURCHASED ? (
         <PurchasedContent />
+      ) : activePage === VIEWER_LABELS.PREVIOUSLY_RENTED ? (
+        <PreviouslyRentedContent />
       ) : (
         <MonoText $use="H4_SemiBold">{sectionTitle}</MonoText>
       )}

--- a/apps/web/components/Feature/Dashboard/ClientViewerPurchased/PreviouslyRentedCollectionCard.tsx
+++ b/apps/web/components/Feature/Dashboard/ClientViewerPurchased/PreviouslyRentedCollectionCard.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+import { MonoText } from "@/components/UI/Monotext";
+import GenericButton from "@/components/UI/GenericButton";
+import { VARIANT } from "@/utils/Constants";
+import PlaylistIcon from "@/assets/icons/PlaylistIcon";
+import type { PurchasedCollectionItem } from "@/utils/dummyData/viewerPurchasedMockData";
+import COLORS from "@repo/ui/colors";
+import { DASHBOARD_VIEWER_PREVIOUSLY_RENTED } from "@/utils/translationKeys";
+import {
+  CollectionActionColumn,
+  CollectionActionsRow,
+  CollectionBody,
+  CollectionBottomBlock,
+  CollectionCoverImage,
+  CollectionElementsPill,
+  CollectionFlexSpacer,
+  CollectionIconSlot,
+  CollectionMetaTop,
+  CollectionRoot,
+  CollectionThumbWrap,
+} from "./styles";
+
+type Props = {
+  item: PurchasedCollectionItem;
+};
+
+export default function PreviouslyRentedCollectionCard({ item }: Props) {
+  const { t } = useTranslation();
+
+  const buyKr = item.buyPriceKr ?? 0;
+  const rentKr = item.rentPriceKr ?? 0;
+
+  return (
+    <CollectionRoot>
+      <CollectionThumbWrap>
+        <CollectionCoverImage
+          src={item.coverSrc}
+          alt=""
+          fill
+          sizes="(max-width: 600px) 100vw, 204px"
+        />
+      </CollectionThumbWrap>
+
+      <CollectionBody>
+        <CollectionMetaTop>
+          <MonoText $use="H5_Medium">{item.title}</MonoText>
+          <MonoText $use="Body_Medium" color={COLORS.neutral.BLACK}>
+            {item.author}
+          </MonoText>
+          <CollectionElementsPill>
+            <CollectionIconSlot>
+              <PlaylistIcon
+                width={22}
+                height={22}
+                color={COLORS.neutral.GRAY_700}
+              />
+            </CollectionIconSlot>
+            <MonoText $use="Body_Bold">
+              {t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.elements, {
+                count: item.elementCount,
+              })}
+            </MonoText>
+          </CollectionElementsPill>
+        </CollectionMetaTop>
+
+        <CollectionFlexSpacer aria-hidden />
+
+        <CollectionBottomBlock>
+          <CollectionActionsRow>
+            <CollectionActionColumn>
+              <GenericButton
+                type="button"
+                variant={VARIANT.PRIMARY}
+                fullWidth
+                style={{ minHeight: 44 }}
+              >
+                {t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.buttons.buy, {
+                  price: buyKr,
+                })}
+              </GenericButton>
+            </CollectionActionColumn>
+            <CollectionActionColumn>
+              <GenericButton
+                type="button"
+                variant={VARIANT.SECONDARY}
+                fullWidth
+                style={{ minHeight: 44 }}
+              >
+                {t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.buttons.rent, {
+                  price: rentKr,
+                })}
+              </GenericButton>
+            </CollectionActionColumn>
+          </CollectionActionsRow>
+        </CollectionBottomBlock>
+      </CollectionBody>
+    </CollectionRoot>
+  );
+}

--- a/apps/web/components/Feature/Dashboard/ClientViewerPurchased/PreviouslyRentedCollectionCard.tsx
+++ b/apps/web/components/Feature/Dashboard/ClientViewerPurchased/PreviouslyRentedCollectionCard.tsx
@@ -2,7 +2,6 @@
 
 import { useTranslation } from "react-i18next";
 import { MonoText } from "@/components/UI/Monotext";
-import GenericButton from "@/components/UI/GenericButton";
 import { VARIANT } from "@/utils/Constants";
 import PlaylistIcon from "@/assets/icons/PlaylistIcon";
 import type { PurchasedCollectionItem } from "@/utils/dummyData/viewerPurchasedMockData";
@@ -20,6 +19,7 @@ import {
   CollectionFlexSpacer,
   CollectionIconSlot,
   CollectionMetaTop,
+  CollectionRentBuyCtaButton,
   CollectionRoot,
   CollectionThumbWrap,
 } from "./styles";
@@ -72,11 +72,10 @@ export default function PreviouslyRentedCollectionCard({ item }: Props) {
         <CollectionBottomBlock>
           <CollectionActionsRow>
             <CollectionActionColumn>
-              <GenericButton
+              <CollectionRentBuyCtaButton
                 type="button"
                 variant={VARIANT.PRIMARY}
                 fullWidth
-                style={{ minHeight: 51, padding: "8px 12px", borderRadius: 16 }}
               >
                 <CollectionActionButtonContent>
                   {t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.buttons.buy, {
@@ -88,14 +87,13 @@ export default function PreviouslyRentedCollectionCard({ item }: Props) {
                     )}
                   </CollectionActionButtonSubtext>
                 </CollectionActionButtonContent>
-              </GenericButton>
+              </CollectionRentBuyCtaButton>
             </CollectionActionColumn>
             <CollectionActionColumn>
-              <GenericButton
+              <CollectionRentBuyCtaButton
                 type="button"
                 variant={VARIANT.SECONDARY}
                 fullWidth
-                style={{ minHeight: 51, padding: "8px 12px", borderRadius: 16 }}
               >
                 <CollectionActionButtonContent>
                   {t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.buttons.rent, {
@@ -107,7 +105,7 @@ export default function PreviouslyRentedCollectionCard({ item }: Props) {
                     )}
                   </CollectionActionButtonSubtext>
                 </CollectionActionButtonContent>
-              </GenericButton>
+              </CollectionRentBuyCtaButton>
             </CollectionActionColumn>
           </CollectionActionsRow>
         </CollectionBottomBlock>

--- a/apps/web/components/Feature/Dashboard/ClientViewerPurchased/PreviouslyRentedCollectionCard.tsx
+++ b/apps/web/components/Feature/Dashboard/ClientViewerPurchased/PreviouslyRentedCollectionCard.tsx
@@ -10,6 +10,8 @@ import COLORS from "@repo/ui/colors";
 import { DASHBOARD_VIEWER_PREVIOUSLY_RENTED } from "@/utils/translationKeys";
 import {
   CollectionActionColumn,
+  CollectionActionButtonContent,
+  CollectionActionButtonSubtext,
   CollectionActionsRow,
   CollectionBody,
   CollectionBottomBlock,
@@ -74,11 +76,18 @@ export default function PreviouslyRentedCollectionCard({ item }: Props) {
                 type="button"
                 variant={VARIANT.PRIMARY}
                 fullWidth
-                style={{ minHeight: 44 }}
+                style={{ minHeight: 51, padding: "8px 12px", borderRadius: 16 }}
               >
-                {t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.buttons.buy, {
-                  price: buyKr,
-                })}
+                <CollectionActionButtonContent>
+                  {t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.buttons.buy, {
+                    price: buyKr,
+                  })}
+                  <CollectionActionButtonSubtext>
+                    {t(
+                      DASHBOARD_VIEWER_PREVIOUSLY_RENTED.buttons.contentSubtext,
+                    )}
+                  </CollectionActionButtonSubtext>
+                </CollectionActionButtonContent>
               </GenericButton>
             </CollectionActionColumn>
             <CollectionActionColumn>
@@ -86,11 +95,18 @@ export default function PreviouslyRentedCollectionCard({ item }: Props) {
                 type="button"
                 variant={VARIANT.SECONDARY}
                 fullWidth
-                style={{ minHeight: 44 }}
+                style={{ minHeight: 51, padding: "8px 12px", borderRadius: 16 }}
               >
-                {t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.buttons.rent, {
-                  price: rentKr,
-                })}
+                <CollectionActionButtonContent>
+                  {t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.buttons.rent, {
+                    price: rentKr,
+                  })}
+                  <CollectionActionButtonSubtext>
+                    {t(
+                      DASHBOARD_VIEWER_PREVIOUSLY_RENTED.buttons.contentSubtext,
+                    )}
+                  </CollectionActionButtonSubtext>
+                </CollectionActionButtonContent>
               </GenericButton>
             </CollectionActionColumn>
           </CollectionActionsRow>

--- a/apps/web/components/Feature/Dashboard/ClientViewerPurchased/PreviouslyRentedContent.tsx
+++ b/apps/web/components/Feature/Dashboard/ClientViewerPurchased/PreviouslyRentedContent.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { MonoText } from "@/components/UI/Monotext";
+import {
+  MOCK_PREVIOUSLY_RENTED_AUDIOS,
+  MOCK_PREVIOUSLY_RENTED_COLLECTIONS,
+  MOCK_PREVIOUSLY_RENTED_PDFS,
+  MOCK_PREVIOUSLY_RENTED_VIDEOS,
+  type PurchasedMediaItem,
+} from "@/utils/dummyData/viewerPurchasedMockData";
+import CollectionsSection from "./Sections/CollectionsSection";
+import PreviouslyRentedCollectionCard from "./PreviouslyRentedCollectionCard";
+import PurchasedMediaSection from "./PurchasedMediaSection";
+import { PageHeader, PageWrap } from "./styles";
+import { SearchIcon } from "@/assets/icons/searchBarIcon";
+import { DASHBOARD_VIEWER_PREVIOUSLY_RENTED } from "@/utils/translationKeys";
+import { purchasedMediaToTutorial } from "@/utils/purchasedMediaToTutorial";
+import { VARIANT } from "@/utils/Constants";
+
+function matchesSearch(q: string, parts: string[]) {
+  const needle = q.trim().toLowerCase();
+  if (!needle) return true;
+  return parts.some((p) => p.toLowerCase().includes(needle));
+}
+
+function filterMedia(
+  searchValue: string,
+  items: PurchasedMediaItem[],
+): PurchasedMediaItem[] {
+  return items.filter((v) =>
+    matchesSearch(searchValue, [v.title, v.author, v.category, v.dateLabel]),
+  );
+}
+
+export default function PreviouslyRentedContent() {
+  const { t } = useTranslation();
+  const [searchValue] = useState("");
+  const getPreviouslyRentedTutorial = useCallback(
+    (item: PurchasedMediaItem) => {
+      const buyKr = item.buyPriceKr ?? 99;
+      const rentKr = item.rentPriceKr ?? 29;
+      return purchasedMediaToTutorial(item, {
+        published: t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.badges.expiredLine, {
+          date: item.dateLabel,
+        }),
+        buttons: [
+          {
+            label: t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.buttons.buy, {
+              price: buyKr,
+            }),
+            variant: VARIANT.PRIMARY,
+          },
+          {
+            label: t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.buttons.rent, {
+              price: rentKr,
+            }),
+            variant: VARIANT.SECONDARY,
+          },
+        ],
+      });
+    },
+    [t],
+  );
+
+  const filteredCollections = useMemo(
+    () =>
+      MOCK_PREVIOUSLY_RENTED_COLLECTIONS.filter((c) =>
+        matchesSearch(searchValue, [c.title, c.author, String(c.elementCount)]),
+      ),
+    [searchValue],
+  );
+
+  const filteredVideos = useMemo(
+    () => filterMedia(searchValue, MOCK_PREVIOUSLY_RENTED_VIDEOS),
+    [searchValue],
+  );
+
+  const filteredAudios = useMemo(
+    () => filterMedia(searchValue, MOCK_PREVIOUSLY_RENTED_AUDIOS),
+    [searchValue],
+  );
+
+  const filteredPdfs = useMemo(
+    () => filterMedia(searchValue, MOCK_PREVIOUSLY_RENTED_PDFS),
+    [searchValue],
+  );
+
+  return (
+    <PageWrap>
+      <PageHeader>
+        <MonoText $use="H4_SemiBold">
+          {t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.title)}
+        </MonoText>
+        <SearchIcon />
+      </PageHeader>
+
+      <CollectionsSection
+        items={filteredCollections}
+        title={t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.sections.collections)}
+        emptyHint={t(
+          DASHBOARD_VIEWER_PREVIOUSLY_RENTED.emptyStates.collections,
+        )}
+        CardComponent={PreviouslyRentedCollectionCard}
+      />
+
+      <PurchasedMediaSection
+        title={t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.sections.videos)}
+        items={filteredVideos}
+        emptyHint={t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.emptyStates.media)}
+        getTutorial={getPreviouslyRentedTutorial}
+      />
+      <PurchasedMediaSection
+        title={t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.sections.audios)}
+        items={filteredAudios}
+        emptyHint={t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.emptyStates.media)}
+        getTutorial={getPreviouslyRentedTutorial}
+      />
+      <PurchasedMediaSection
+        title={t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.sections.pdf)}
+        items={filteredPdfs}
+        emptyHint={t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.emptyStates.media)}
+        getTutorial={getPreviouslyRentedTutorial}
+      />
+    </PageWrap>
+  );
+}

--- a/apps/web/components/Feature/Dashboard/ClientViewerPurchased/PreviouslyRentedContent.tsx
+++ b/apps/web/components/Feature/Dashboard/ClientViewerPurchased/PreviouslyRentedContent.tsx
@@ -41,6 +41,7 @@ export default function PreviouslyRentedContent() {
     (item: PurchasedMediaItem) => {
       const buyKr = item.buyPriceKr ?? 99;
       const rentKr = item.rentPriceKr ?? 29;
+      const actionButtonStyle = { borderRadius: 16 };
       return purchasedMediaToTutorial(item, {
         published: t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.badges.expiredLine, {
           date: item.dateLabel,
@@ -51,12 +52,14 @@ export default function PreviouslyRentedContent() {
               price: buyKr,
             }),
             variant: VARIANT.PRIMARY,
+            style: actionButtonStyle,
           },
           {
             label: t(DASHBOARD_VIEWER_PREVIOUSLY_RENTED.buttons.rent, {
               price: rentKr,
             }),
             variant: VARIANT.SECONDARY,
+            style: actionButtonStyle,
           },
         ],
       });

--- a/apps/web/components/Feature/Dashboard/ClientViewerPurchased/PurchasedMediaSection.tsx
+++ b/apps/web/components/Feature/Dashboard/ClientViewerPurchased/PurchasedMediaSection.tsx
@@ -4,6 +4,7 @@ import TutorialCard from "@/components/Feature/TutorialVideos/TutorialCard";
 import type { PurchasedMediaItem } from "@/utils/dummyData/viewerPurchasedMockData";
 import { VIEWER_PURCHASED_PLACEHOLDERS } from "@/utils/dummyData/viewerPurchasedMockData";
 import { purchasedMediaToTutorial } from "@/utils/purchasedMediaToTutorial";
+import type { TutorialVideo } from "@/utils/types";
 import {
   EmptyHint,
   MediaRow,
@@ -18,12 +19,14 @@ type Props = {
   title: string;
   items: PurchasedMediaItem[];
   emptyHint?: string;
+  getTutorial?: (item: PurchasedMediaItem) => TutorialVideo;
 };
 
 export default function PurchasedMediaSection({
   title,
   items,
   emptyHint = VIEWER_PURCHASED_PLACEHOLDERS.emptyMedia,
+  getTutorial,
 }: Props) {
   return (
     <SectionBlock>
@@ -37,7 +40,13 @@ export default function PurchasedMediaSection({
         <MediaRow>
           {items.map((item) => (
             <MediaRowSlot key={item.id}>
-              <TutorialCard tutorial={purchasedMediaToTutorial(item)} />
+              <TutorialCard
+                tutorial={
+                  getTutorial
+                    ? getTutorial(item)
+                    : purchasedMediaToTutorial(item)
+                }
+              />
             </MediaRowSlot>
           ))}
         </MediaRow>

--- a/apps/web/components/Feature/Dashboard/ClientViewerPurchased/Sections/CollectionsSection.tsx
+++ b/apps/web/components/Feature/Dashboard/ClientViewerPurchased/Sections/CollectionsSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentType } from "react";
 import { useTranslation } from "react-i18next";
 import PurchasedCollectionCard from "../PurchasedCollectionCard";
 import type { PurchasedCollectionItem } from "@/utils/dummyData/viewerPurchasedMockData";
@@ -16,28 +17,36 @@ import { DASHBOARD_VIEWER_PURCHASED } from "@/utils/translationKeys";
 
 type Props = {
   items: PurchasedCollectionItem[];
+  title?: string;
+  emptyHint?: string;
+  CardComponent?: ComponentType<{ item: PurchasedCollectionItem }>;
 };
 
-export default function CollectionsSection({ items }: Props) {
+export default function CollectionsSection({
+  items,
+  title,
+  emptyHint,
+  CardComponent = PurchasedCollectionCard,
+}: Props) {
   const { t } = useTranslation();
+  const sectionTitle =
+    title ?? t(DASHBOARD_VIEWER_PURCHASED.sections.collections);
+  const emptyCopy =
+    emptyHint ?? t(DASHBOARD_VIEWER_PURCHASED.emptyStates.collections);
 
   return (
     <SectionBlock>
       <SectionHeaderRow>
-        <SectionTitle>
-          {t(DASHBOARD_VIEWER_PURCHASED.sections.collections)}
-        </SectionTitle>
+        <SectionTitle>{sectionTitle}</SectionTitle>
         <LeftIcon />
       </SectionHeaderRow>
       {items.length === 0 ? (
-        <EmptyHint>
-          {t(DASHBOARD_VIEWER_PURCHASED.emptyStates.collections)}
-        </EmptyHint>
+        <EmptyHint>{emptyCopy}</EmptyHint>
       ) : (
         <CollectionsList>
           {items.map((item) => (
             <CollectionCardSlot key={item.id}>
-              <PurchasedCollectionCard item={item} />
+              <CardComponent item={item} />
             </CollectionCardSlot>
           ))}
         </CollectionsList>

--- a/apps/web/components/Feature/Dashboard/ClientViewerPurchased/styles.ts
+++ b/apps/web/components/Feature/Dashboard/ClientViewerPurchased/styles.ts
@@ -1,6 +1,7 @@
 import { media } from "@repo/ui/breakpoints";
 import NextImage from "next/image";
 import styled from "styled-components";
+import GenericButton from "@/components/UI/GenericButton";
 import { MonoText } from "@/components/UI/Monotext";
 
 export const PageHeader = styled.div`
@@ -233,6 +234,12 @@ export const CollectionActionColumn = styled.div`
   flex-direction: column;
   gap: ${({ theme }) => theme.spacing(1)};
   min-width: 0;
+`;
+
+export const CollectionRentBuyCtaButton = styled(GenericButton)`
+  min-height: 51px;
+  padding: 8px 12px;
+  border-radius: 12px;
 `;
 
 export const CollectionActionButtonContent = styled.span`

--- a/apps/web/components/Feature/Dashboard/ClientViewerPurchased/styles.ts
+++ b/apps/web/components/Feature/Dashboard/ClientViewerPurchased/styles.ts
@@ -226,6 +226,10 @@ export const CollectionActionsRow = styled.div`
   align-items: stretch;
   gap: ${({ theme }) => theme.spacing(2)};
   width: 100%;
+
+  ${media.desktop} {
+    flex-direction: column;
+  }
 `;
 
 export const CollectionActionColumn = styled.div`
@@ -250,6 +254,7 @@ export const CollectionActionButtonContent = styled.span`
   gap: 2px;
   min-width: 0;
   line-height: 1;
+  white-space: nowrap;
 `;
 
 export const CollectionActionButtonSubtext = styled.span`

--- a/apps/web/components/Feature/Dashboard/ClientViewerPurchased/styles.ts
+++ b/apps/web/components/Feature/Dashboard/ClientViewerPurchased/styles.ts
@@ -218,3 +218,19 @@ export const CollectionIconSlot = styled.span`
   flex-shrink: 0;
   line-height: 0;
 `;
+
+export const CollectionActionsRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: ${({ theme }) => theme.spacing(2)};
+  width: 100%;
+`;
+
+export const CollectionActionColumn = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(1)};
+  min-width: 0;
+`;

--- a/apps/web/components/Feature/Dashboard/ClientViewerPurchased/styles.ts
+++ b/apps/web/components/Feature/Dashboard/ClientViewerPurchased/styles.ts
@@ -234,3 +234,24 @@ export const CollectionActionColumn = styled.div`
   gap: ${({ theme }) => theme.spacing(1)};
   min-width: 0;
 `;
+
+export const CollectionActionButtonContent = styled.span`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  min-width: 0;
+  line-height: 1;
+`;
+
+export const CollectionActionButtonSubtext = styled.span`
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  ${({ theme }) => theme.typography.Body_Small}
+  color: currentColor;
+  opacity: 0.6;
+`;

--- a/apps/web/components/Feature/TutorialVideos/TutorialCard/index.tsx
+++ b/apps/web/components/Feature/TutorialVideos/TutorialCard/index.tsx
@@ -90,6 +90,7 @@ function TutorialCard({ tutorial }: TutorialCardProps) {
                 fullWidth={button.fullWidth}
                 size={button.size}
                 minWidth={button.minWidth}
+                style={button.style}
               >
                 {button.label}
               </GenericButton>
@@ -101,6 +102,7 @@ function TutorialCard({ tutorial }: TutorialCardProps) {
                 fullWidth={button.fullWidth}
                 size={button.size}
                 minWidth={button.minWidth}
+                style={button.style}
               >
                 {button.label}
               </GenericButton>

--- a/apps/web/components/Feature/TutorialVideos/TutorialCard/styles.ts
+++ b/apps/web/components/Feature/TutorialVideos/TutorialCard/styles.ts
@@ -118,7 +118,16 @@ export const ActionRow = styled.div`
   flex-wrap: wrap;
 
   > * {
-    flex: 1;
+    display: flex;
+    width: 120px;
+    height: 33px;
+    padding: 9px 34px;
+    box-sizing: border-box;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    flex: 0 0 120px;
     min-width: 0;
+    white-space: nowrap;
   }
 `;

--- a/apps/web/components/Feature/TutorialVideos/TutorialCard/styles.ts
+++ b/apps/web/components/Feature/TutorialVideos/TutorialCard/styles.ts
@@ -130,4 +130,13 @@ export const ActionRow = styled.div`
     min-width: 0;
     white-space: nowrap;
   }
+
+  @media (max-width: 280px) {
+    flex-direction: column;
+
+    > * {
+      width: 100%;
+      flex-basis: auto;
+    }
+  }
 `;

--- a/apps/web/locals/da.json
+++ b/apps/web/locals/da.json
@@ -989,7 +989,8 @@
       },
       "buttons": {
         "buy": "Køb {{price}} kr",
-        "rent": "Lej {{price}} kr"
+        "rent": "Lej {{price}} kr",
+        "contentSubtext": "Indholdsundertekst"
       },
       "badges": {
         "expiredLine": "Udløb den {{date}}"

--- a/apps/web/locals/da.json
+++ b/apps/web/locals/da.json
@@ -979,6 +979,27 @@
         "media": "Ingen elementer matcher din søgning."
       }
     },
+    "viewerPreviouslyRented": {
+      "title": "Tidligere lejet",
+      "sections": {
+        "collections": "Samlinger",
+        "videos": "Videoer",
+        "audios": "Lydfiler",
+        "pdf": "PDF"
+      },
+      "buttons": {
+        "buy": "Køb {{price}} kr",
+        "rent": "Lej {{price}} kr"
+      },
+      "badges": {
+        "expiredLine": "Udløb den {{date}}"
+      },
+      "elements": "{{count}} elementer",
+      "emptyStates": {
+        "collections": "Ingen samlinger matcher din søgning.",
+        "media": "Ingen elementer matcher din søgning."
+      }
+    },
     "logoutModal": {
       "title": "Log ud",
       "message": "Er du sikker på, at du vil logge ud som {{email}}?",

--- a/apps/web/locals/en.json
+++ b/apps/web/locals/en.json
@@ -989,7 +989,8 @@
       },
       "buttons": {
         "buy": "Buy {{price}} kr",
-        "rent": "Rent {{price}} kr"
+        "rent": "Rent {{price}} kr",
+        "contentSubtext": "Content subtext"
       },
       "badges": {
         "expiredLine": "Expired on {{date}}"

--- a/apps/web/locals/en.json
+++ b/apps/web/locals/en.json
@@ -979,6 +979,27 @@
         "media": "No items match your search."
       }
     },
+    "viewerPreviouslyRented": {
+      "title": "Previously Rented",
+      "sections": {
+        "collections": "Collections",
+        "videos": "Videos",
+        "audios": "Audios",
+        "pdf": "PDF"
+      },
+      "buttons": {
+        "buy": "Buy {{price}} kr",
+        "rent": "Rent {{price}} kr"
+      },
+      "badges": {
+        "expiredLine": "Expired on {{date}}"
+      },
+      "elements": "{{count}} elements",
+      "emptyStates": {
+        "collections": "No collections match your search.",
+        "media": "No items match your search."
+      }
+    },
     "logoutModal": {
       "title": "Log out",
       "message": "Are you sure you want to log out as {{email}}?",

--- a/apps/web/utils/dummyData/viewerPurchasedMockData.ts
+++ b/apps/web/utils/dummyData/viewerPurchasedMockData.ts
@@ -23,6 +23,8 @@ export type PurchasedMediaItem = {
   title: string;
   author: string;
   dateLabel: string;
+  buyPriceKr?: number;
+  rentPriceKr?: number;
 };
 
 export type PurchasedCollectionItem = {
@@ -31,6 +33,9 @@ export type PurchasedCollectionItem = {
   author: string;
   elementCount: number;
   coverSrc: string;
+  /** Optional pricing for rent/buy CTAs (e.g. previously rented). */
+  buyPriceKr?: number;
+  rentPriceKr?: number;
 };
 
 export const VIEWER_PURCHASED_PLACEHOLDERS = {
@@ -170,5 +175,167 @@ export const MOCK_PURCHASED_PDFS: PurchasedMediaItem[] = [
     title: "Journal prompts",
     author: "Oliver Smith",
     dateLabel: "4 February 2024",
+  },
+];
+
+export const MOCK_PREVIOUSLY_RENTED_COLLECTIONS: PurchasedCollectionItem[] = [
+  {
+    id: "pr-c1",
+    title: "The Mind's Palette",
+    author: "Oliver Smith",
+    elementCount: 15,
+    coverSrc: DESIGN_IMG_1,
+    buyPriceKr: 149,
+    rentPriceKr: 49,
+  },
+  {
+    id: "pr-c2",
+    title: "Urban Stories",
+    author: "Maya Chen",
+    elementCount: 8,
+    coverSrc: DESIGN_IMG_2,
+    buyPriceKr: 129,
+    rentPriceKr: 39,
+  },
+];
+
+export const MOCK_PREVIOUSLY_RENTED_VIDEOS: PurchasedMediaItem[] = [
+  {
+    id: "pr-v1",
+    mediaType: PURCHASED_MEDIA_TYPES.VIDEO,
+    category: "Food",
+    thumbSrc: DESIGN_IMG_1,
+    title: "Cognitive Behavioral Techn…",
+    author: "Dr. Emily Chen",
+    dateLabel: "3 November 2025",
+    buyPriceKr: 149,
+    rentPriceKr: 49,
+  },
+  {
+    id: "pr-v2",
+    mediaType: PURCHASED_MEDIA_TYPES.VIDEO,
+    category: "Education",
+    thumbSrc: DESIGN_IMG_2,
+    title: "Evening wind-down",
+    author: "Maya Chen",
+    dateLabel: "3 November 2025",
+    buyPriceKr: 129,
+    rentPriceKr: 39,
+  },
+  {
+    id: "pr-v3",
+    mediaType: PURCHASED_MEDIA_TYPES.VIDEO,
+    category: "Travel",
+    thumbSrc: DESIGN_IMG_3,
+    title: "Coastline walk",
+    author: "Sam Rivera",
+    dateLabel: "28 October 2025",
+    buyPriceKr: 99,
+    rentPriceKr: 29,
+  },
+  {
+    id: "pr-v4",
+    mediaType: PURCHASED_MEDIA_TYPES.VIDEO,
+    category: "Education",
+    thumbSrc: DESIGN_IMG_1,
+    title: "Systems 101",
+    author: "Oliver Smith",
+    dateLabel: "15 October 2025",
+    buyPriceKr: 119,
+    rentPriceKr: 35,
+  },
+];
+
+export const MOCK_PREVIOUSLY_RENTED_AUDIOS: PurchasedMediaItem[] = [
+  {
+    id: "pr-a1",
+    mediaType: PURCHASED_MEDIA_TYPES.AUDIO,
+    category: "Food",
+    thumbSrc: DESIGN_IMG_2,
+    title: "The Mind's Palette",
+    author: "Oliver Smith",
+    dateLabel: "3 November 2025",
+    buyPriceKr: 89,
+    rentPriceKr: 25,
+  },
+  {
+    id: "pr-a2",
+    mediaType: PURCHASED_MEDIA_TYPES.AUDIO,
+    category: "Education",
+    thumbSrc: DESIGN_IMG_3,
+    title: "Lecture notes",
+    author: "Maya Chen",
+    dateLabel: "1 November 2025",
+    buyPriceKr: 79,
+    rentPriceKr: 22,
+  },
+  {
+    id: "pr-a3",
+    mediaType: PURCHASED_MEDIA_TYPES.AUDIO,
+    category: "Travel",
+    thumbSrc: DESIGN_IMG_1,
+    title: "City sounds",
+    author: "Sam Rivera",
+    dateLabel: "28 October 2025",
+    buyPriceKr: 69,
+    rentPriceKr: 19,
+  },
+  {
+    id: "pr-a4",
+    mediaType: PURCHASED_MEDIA_TYPES.AUDIO,
+    category: "Relaxation",
+    thumbSrc: DESIGN_IMG_2,
+    title: "Ambient hour",
+    author: "Oliver Smith",
+    dateLabel: "20 October 2025",
+    buyPriceKr: 59,
+    rentPriceKr: 15,
+  },
+];
+
+export const MOCK_PREVIOUSLY_RENTED_PDFS: PurchasedMediaItem[] = [
+  {
+    id: "pr-p1",
+    mediaType: PURCHASED_MEDIA_TYPES.PDF,
+    category: "Food",
+    thumbSrc: DESIGN_IMG_3,
+    title: "The Mind's Palette",
+    author: "Oliver Smith",
+    dateLabel: "3 November 2025",
+    buyPriceKr: 49,
+    rentPriceKr: 15,
+  },
+  {
+    id: "pr-p2",
+    mediaType: PURCHASED_MEDIA_TYPES.PDF,
+    category: "Education",
+    thumbSrc: DESIGN_IMG_1,
+    title: "Course reader",
+    author: "Maya Chen",
+    dateLabel: "29 October 2025",
+    buyPriceKr: 39,
+    rentPriceKr: 12,
+  },
+  {
+    id: "pr-p3",
+    mediaType: PURCHASED_MEDIA_TYPES.PDF,
+    category: "Travel",
+    thumbSrc: DESIGN_IMG_2,
+    title: "City guide",
+    author: "Sam Rivera",
+    dateLabel: "25 October 2025",
+    buyPriceKr: 29,
+    rentPriceKr: 9,
+  },
+  {
+    id: "pr-p4",
+    mediaType: PURCHASED_MEDIA_TYPES.PDF,
+    category: "Relaxation",
+    thumbSrc: DESIGN_IMG_3,
+    title: "Journal prompts",
+    author: "Oliver Smith",
+    dateLabel: "18 October 2025",
+    buyPriceKr: 19,
+    rentPriceKr: 7,
   },
 ];

--- a/apps/web/utils/dummyData/viewerPurchasedMockData.ts
+++ b/apps/web/utils/dummyData/viewerPurchasedMockData.ts
@@ -33,7 +33,6 @@ export type PurchasedCollectionItem = {
   author: string;
   elementCount: number;
   coverSrc: string;
-  /** Optional pricing for rent/buy CTAs (e.g. previously rented). */
   buyPriceKr?: number;
   rentPriceKr?: number;
 };

--- a/apps/web/utils/purchasedMediaToTutorial.ts
+++ b/apps/web/utils/purchasedMediaToTutorial.ts
@@ -1,5 +1,9 @@
 import { VARIANT } from "@/utils/Constants";
-import { FORMAT_TYPE, type TutorialVideo } from "@/utils/types";
+import {
+  FORMAT_TYPE,
+  type TutorialButton,
+  type TutorialVideo,
+} from "@/utils/types";
 import {
   PURCHASED_MEDIA_TYPES,
   type PurchasedMediaItem,
@@ -26,25 +30,35 @@ const LABEL: Record<PurchasedMediaItem["mediaType"], string> = {
   [PURCHASED_MEDIA_TYPES.PDF]: "PDF",
 };
 
+export type PurchasedMediaTutorialOptions = {
+  /** Overrides card “published” line (e.g. “Expired on …”). */
+  published?: string;
+  /** Full footer button row; defaults to single play/open action. */
+  buttons?: TutorialButton[];
+};
+
 export function purchasedMediaToTutorial(
   item: PurchasedMediaItem,
+  options?: PurchasedMediaTutorialOptions,
 ): TutorialVideo {
+  const defaultButtons: TutorialButton[] = [
+    {
+      label: ACTION[item.mediaType],
+      variant: VARIANT.SECONDARY,
+    },
+  ];
+
   return {
     id: item.id,
     title: item.title,
     category: item.category,
     creator: item.author,
-    published: item.dateLabel,
+    published: options?.published ?? item.dateLabel,
     focus: "",
     level: "",
     formatLabel: LABEL[item.mediaType],
     formatType: FORMAT[item.mediaType],
     image: item.thumbSrc,
-    buttons: [
-      {
-        label: ACTION[item.mediaType],
-        variant: VARIANT.SECONDARY,
-      },
-    ],
+    buttons: options?.buttons ?? defaultButtons,
   };
 }

--- a/apps/web/utils/purchasedMediaToTutorial.ts
+++ b/apps/web/utils/purchasedMediaToTutorial.ts
@@ -31,9 +31,7 @@ const LABEL: Record<PurchasedMediaItem["mediaType"], string> = {
 };
 
 export type PurchasedMediaTutorialOptions = {
-  /** Overrides card “published” line (e.g. “Expired on …”). */
   published?: string;
-  /** Full footer button row; defaults to single play/open action. */
   buttons?: TutorialButton[];
 };
 

--- a/apps/web/utils/translationKeys.ts
+++ b/apps/web/utils/translationKeys.ts
@@ -185,6 +185,28 @@ export const DASHBOARD_VIEWER_PURCHASED = {
   },
 };
 
+export const DASHBOARD_VIEWER_PREVIOUSLY_RENTED = {
+  title: "dashboard.viewerPreviouslyRented.title",
+  sections: {
+    collections: "dashboard.viewerPreviouslyRented.sections.collections",
+    videos: "dashboard.viewerPreviouslyRented.sections.videos",
+    audios: "dashboard.viewerPreviouslyRented.sections.audios",
+    pdf: "dashboard.viewerPreviouslyRented.sections.pdf",
+  },
+  buttons: {
+    buy: "dashboard.viewerPreviouslyRented.buttons.buy",
+    rent: "dashboard.viewerPreviouslyRented.buttons.rent",
+  },
+  badges: {
+    expiredLine: "dashboard.viewerPreviouslyRented.badges.expiredLine",
+  },
+  elements: "dashboard.viewerPreviouslyRented.elements",
+  emptyStates: {
+    collections: "dashboard.viewerPreviouslyRented.emptyStates.collections",
+    media: "dashboard.viewerPreviouslyRented.emptyStates.media",
+  },
+};
+
 export const CONTENTS = {
   title: "contents.title",
   actions: {

--- a/apps/web/utils/translationKeys.ts
+++ b/apps/web/utils/translationKeys.ts
@@ -196,6 +196,7 @@ export const DASHBOARD_VIEWER_PREVIOUSLY_RENTED = {
   buttons: {
     buy: "dashboard.viewerPreviouslyRented.buttons.buy",
     rent: "dashboard.viewerPreviouslyRented.buttons.rent",
+    contentSubtext: "dashboard.viewerPreviouslyRented.buttons.contentSubtext",
   },
   badges: {
     expiredLine: "dashboard.viewerPreviouslyRented.badges.expiredLine",

--- a/apps/web/utils/types.ts
+++ b/apps/web/utils/types.ts
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import type { ImageSource, Variant } from "@/utils/Constants";
 import type { ButtonSize } from "@/components/UI/GenericButton/variants";
 
@@ -18,6 +19,7 @@ export type TutorialButton = {
   fullWidth?: boolean;
   size?: ButtonSize;
   minWidth?: string;
+  style?: CSSProperties;
 };
 
 export type TutorialVideo = {


### PR DESCRIPTION
# Description

Adds the Previously Rented page UI to the Viewer Dashboard on the web platform.

Closes #449

## Type of change

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/77568528-70f3-4272-8b1c-e3d84663581c" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7c12c9de-d75d-43ec-a0b7-7c0fd091e6dd" />

