### PR TITLE
#478: Hardcoded dev API URL and no env validation

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:4001/api/v1

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+const requiredApiUrlSchema = z.preprocess(
+  (value) => (typeof value === "string" ? value : ""),
+  z
+    .string()
+    .trim()
+    .min(1, "NEXT_PUBLIC_API_URL is required")
+    .pipe(
+      z
+        .string()
+        .url("NEXT_PUBLIC_API_URL must be a valid absolute URL")
+        .refine((value) => !value.endsWith("/"), {
+          message: "NEXT_PUBLIC_API_URL must not have a trailing slash",
+        }),
+    ),
+);
+
+const basePublicEnvSchema = z.object({
+  NEXT_PUBLIC_API_URL: requiredApiUrlSchema,
+});
+
+const productionPublicEnvSchema = basePublicEnvSchema.extend({
+  NEXT_PUBLIC_API_URL: basePublicEnvSchema.shape.NEXT_PUBLIC_API_URL.refine(
+    (value) => value.startsWith("https://"),
+    {
+      message: "NEXT_PUBLIC_API_URL must use https:// in production",
+    },
+  ),
+});
+
+function resolveApiBaseUrl(): string {
+  const schema =
+    process.env.NODE_ENV === "production"
+      ? productionPublicEnvSchema
+      : basePublicEnvSchema;
+
+  const parsed = schema.safeParse({
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+  });
+
+  if (!parsed.success) {
+    throw new Error(
+      `[env] Invalid environment configuration:\n${parsed.error.issues
+        .map((issue) => `  - ${issue.message}`)
+        .join("\n")}`,
+    );
+  }
+
+  return parsed.data.NEXT_PUBLIC_API_URL;
+}
+
+export const API_BASE_URL = resolveApiBaseUrl();

--- a/apps/web/lib/http/config.ts
+++ b/apps/web/lib/http/config.ts
@@ -1,4 +1,3 @@
-export const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4001/api/v1";
+export { API_BASE_URL } from "@/lib/env";
 
 export const REQUEST_TIMEOUT = 30_000;


### PR DESCRIPTION
# Description

Fixes hardcoded development API URL and adds environment validation to prevent production builds from pointing to localhost:4001.

Closes #478

## Type of change

## ✅ Verification

Verified by running:

```bash
env -u NEXT_PUBLIC_API_URL pnpm build
```

### Result

The build fails with:

```
[env] Invalid environment configuration:
  - NEXT_PUBLIC_API_URL is required
```

This confirms that production builds no longer succeed when `NEXT_PUBLIC_API_URL` is missing, preventing accidental deployment with an invalid API endpoint.

---

## 📸 Screenshot

![Build Failure Screenshot](https://github.com/user-attachments/assets/76dd2e43-61cb-4bd3-8443-c77b934a7786)

---
