### PR TITLE
#500: Implement Keyboard Navigation for Custom Dropdown Components

### DIFF
--- a/apps/web/components/UI/GenericTabs/index.tsx
+++ b/apps/web/components/UI/GenericTabs/index.tsx
@@ -10,6 +10,7 @@ import {
   TabButton,
   TabsRow,
 } from "./styles";
+import { useTabsKeyboard } from "@/hooks/useTabsKeyboard";
 
 type GenericTabItem<T extends string> = {
   key: T;
@@ -31,6 +32,7 @@ type GenericTabsProps<T extends string> = {
   activeTab: T;
   onTabChange: (key: T) => void;
   search?: SearchConfig;
+  tabPanelId?: string;
 };
 
 export default function GenericTabs<T extends string>({
@@ -38,10 +40,16 @@ export default function GenericTabs<T extends string>({
   activeTab,
   onTabChange,
   search,
+  tabPanelId,
 }: GenericTabsProps<T>) {
   const theme = useTheme();
   const searchInputRef = useRef<HTMLInputElement>(null);
   const isSearchOpen = search?.alwaysOpen ? true : !!search?.open;
+
+  const { tabRefs, handleTabKeyDown } = useTabsKeyboard({
+    tabs,
+    onTabChange,
+  });
 
   useEffect(() => {
     if (isSearchOpen) {
@@ -50,13 +58,21 @@ export default function GenericTabs<T extends string>({
   }, [isSearchOpen]);
 
   return (
-    <TabsRow>
-      {tabs.map((tab) => (
+    <TabsRow role="tablist">
+      {tabs.map((tab, i) => (
         <TabButton
           key={tab.key}
+          ref={(el) => {
+            tabRefs.current[i] = el;
+          }}
           type="button"
+          role="tab"
+          tabIndex={activeTab === tab.key ? 0 : -1}
+          aria-selected={activeTab === tab.key}
+          aria-controls={tabPanelId ?? `tabpanel-${tab.key}`}
           $active={activeTab === tab.key}
           onClick={() => onTabChange(tab.key)}
+          onKeyDown={(e) => handleTabKeyDown(e, i)}
         >
           {tab.label}
         </TabButton>

--- a/apps/web/components/UI/GenericTabs/styles.ts
+++ b/apps/web/components/UI/GenericTabs/styles.ts
@@ -20,6 +20,15 @@ export const TabButton = styled.button<{ $active: boolean }>`
   border-bottom: 2px solid
     ${({ $active, theme }) =>
       $active ? theme.colors.primary.BLACK : "transparent"};
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.colors.primary.BLACK};
+    border-radius: 2px;
+  }
 `;
 
 export const SearchArea = styled.div<{ $open: boolean }>`

--- a/apps/web/components/UI/InputFields/DropdownField.tsx
+++ b/apps/web/components/UI/InputFields/DropdownField.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useMemo } from "react";
+import React, { useId, useRef, useState, useMemo } from "react";
 import {
   Container,
   Label,
@@ -15,6 +15,7 @@ import { ArrowIcon } from "@/assets/icons/arrowIcon";
 import { SelectedCheckIcon } from "@/assets/icons";
 import { Directions } from "@/utils/ui";
 import { useClickOutside } from "@/hooks/useClickOutside";
+import { useDropdownKeyboard } from "@/hooks/useDropdownKeyboard";
 
 export type OptionItem = {
   value: string;
@@ -41,23 +42,55 @@ export default function DropdownField({
   renderSelectedValue,
 }: Props) {
   const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement | null>(null);
-
-  useClickOutside({ ref, enabled: open, handler: () => setOpen(false) });
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const uid = useId();
+  const listboxId = `dropdown-listbox-${uid}`;
 
   const selected = useMemo(() => {
     return options.find((o) => o.value === value) || options[0] || null;
   }, [options, value]);
 
+  const {
+    activeIndex,
+    optionRefs,
+    handleTriggerKeyDown,
+    handleOptionKeyDown,
+    resetActiveIndex,
+  } = useDropdownKeyboard({
+    isOpen: open,
+    setIsOpen: setOpen,
+    optionsLength: options.length,
+    onSelect: (index) => onChange?.(options[index].value),
+    triggerRef,
+  });
+
+  useClickOutside({
+    ref: containerRef,
+    enabled: open,
+    handler: () => {
+      setOpen(false);
+      resetActiveIndex();
+    },
+  });
+
   return (
-    <Container ref={ref} style={{ position: "relative" }}>
+    <Container ref={containerRef} style={{ position: "relative" }}>
       {label && <Label as={MonoText}>{label}</Label>}
 
       <div style={{ position: "relative" }}>
         <Field
-          onClick={() => setOpen((s) => !s)}
-          role="button"
+          ref={triggerRef as React.Ref<HTMLDivElement>}
+          onClick={() => {
+            setOpen((s) => !s);
+            resetActiveIndex();
+          }}
+          onKeyDown={handleTriggerKeyDown}
+          role="combobox"
+          tabIndex={0}
           aria-haspopup="listbox"
+          aria-expanded={open}
+          aria-controls={listboxId}
         >
           <Selected>
             {renderSelectedValue ? (
@@ -77,15 +110,24 @@ export default function DropdownField({
         </Field>
 
         {open && (
-          <Menu role="listbox">
-            {options.map((opt) => (
+          <Menu role="listbox" id={listboxId}>
+            {options.map((opt, i) => (
               <Item
                 key={opt.value}
+                ref={(el) => {
+                  optionRefs.current[i] = el;
+                }}
                 type="button"
+                role="option"
+                tabIndex={-1}
+                aria-selected={activeIndex === i}
                 onClick={() => {
                   onChange?.(opt.value);
                   setOpen(false);
+                  resetActiveIndex();
+                  triggerRef.current?.focus();
                 }}
+                onKeyDown={(e) => handleOptionKeyDown(e, i)}
               >
                 <ItemContent>
                   {opt.label || opt.labelKey || opt.value}

--- a/apps/web/components/UI/InputFields/styles.ts
+++ b/apps/web/components/UI/InputFields/styles.ts
@@ -227,6 +227,16 @@ export const Field = styled.div`
   justify-content: space-between;
   cursor: pointer;
   min-height: 44px;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.colors.primary.BLACK};
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 `;
 
 export const Selected = styled.div`
@@ -264,6 +274,16 @@ export const Item = styled.button`
   gap: 10px;
   &:hover {
     background: ${({ theme }) => theme.colors.neutral.GRAY_100};
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.colors.primary.BLACK};
+    outline-offset: -2px;
+    border-radius: 2px;
   }
 `;
 

--- a/apps/web/hooks/useDropdownKeyboard.ts
+++ b/apps/web/hooks/useDropdownKeyboard.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { KEYBOARD_KEYS } from "@/utils/ui";
 
 type UseDropdownKeyboardOptions = {
   isOpen: boolean;
@@ -33,8 +34,8 @@ export function useDropdownKeyboard({
   const handleTriggerKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       switch (e.key) {
-        case "Enter":
-        case " ":
+        case KEYBOARD_KEYS.ENTER:
+        case KEYBOARD_KEYS.SPACE:
           e.preventDefault();
           if (isOpen) {
             setIsOpen(false);
@@ -44,17 +45,17 @@ export function useDropdownKeyboard({
             setActiveIndex(0);
           }
           break;
-        case "ArrowDown":
+        case KEYBOARD_KEYS.ARROW_DOWN:
           e.preventDefault();
           setIsOpen(true);
           setActiveIndex(0);
           break;
-        case "ArrowUp":
+        case KEYBOARD_KEYS.ARROW_UP:
           e.preventDefault();
           setIsOpen(true);
           setActiveIndex(optionsLength - 1);
           break;
-        case "Escape":
+        case KEYBOARD_KEYS.ESCAPE:
           if (isOpen) {
             setIsOpen(false);
             setActiveIndex(-1);
@@ -69,36 +70,36 @@ export function useDropdownKeyboard({
   const handleOptionKeyDown = useCallback(
     (e: React.KeyboardEvent, index: number) => {
       switch (e.key) {
-        case "ArrowDown":
+        case KEYBOARD_KEYS.ARROW_DOWN:
           e.preventDefault();
           setActiveIndex((prev) => Math.min(prev + 1, optionsLength - 1));
           break;
-        case "ArrowUp":
+        case KEYBOARD_KEYS.ARROW_UP:
           e.preventDefault();
           setActiveIndex((prev) => Math.max(prev - 1, 0));
           break;
-        case "Home":
+        case KEYBOARD_KEYS.HOME:
           e.preventDefault();
           setActiveIndex(0);
           break;
-        case "End":
+        case KEYBOARD_KEYS.END:
           e.preventDefault();
           setActiveIndex(optionsLength - 1);
           break;
-        case "Enter":
-        case " ":
+        case KEYBOARD_KEYS.ENTER:
+        case KEYBOARD_KEYS.SPACE:
           e.preventDefault();
           onSelect(index);
           setIsOpen(false);
           setActiveIndex(-1);
           triggerRef.current?.focus();
           break;
-        case "Escape":
+        case KEYBOARD_KEYS.ESCAPE:
           setIsOpen(false);
           setActiveIndex(-1);
           triggerRef.current?.focus();
           break;
-        case "Tab":
+        case KEYBOARD_KEYS.TAB:
           setIsOpen(false);
           setActiveIndex(-1);
           break;

--- a/apps/web/hooks/useDropdownKeyboard.ts
+++ b/apps/web/hooks/useDropdownKeyboard.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type UseDropdownKeyboardOptions = {
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  optionsLength: number;
+  onSelect: (index: number) => void;
+  triggerRef: React.RefObject<HTMLElement | null>;
+};
+
+export function useDropdownKeyboard({
+  isOpen,
+  setIsOpen,
+  optionsLength,
+  onSelect,
+  triggerRef,
+}: UseDropdownKeyboardOptions) {
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const optionRefs = useRef<(HTMLElement | null)[]>([]);
+
+  const resetActiveIndex = useCallback(() => {
+    setActiveIndex(-1);
+  }, []);
+
+  const resolvedActiveIndex = isOpen ? activeIndex : -1;
+
+  useEffect(() => {
+    if (isOpen && resolvedActiveIndex >= 0) {
+      optionRefs.current[resolvedActiveIndex]?.focus();
+    }
+  }, [resolvedActiveIndex, isOpen]);
+
+  const handleTriggerKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case "Enter":
+        case " ":
+          e.preventDefault();
+          if (isOpen) {
+            setIsOpen(false);
+            setActiveIndex(-1);
+          } else {
+            setIsOpen(true);
+            setActiveIndex(0);
+          }
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          setIsOpen(true);
+          setActiveIndex(0);
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setIsOpen(true);
+          setActiveIndex(optionsLength - 1);
+          break;
+        case "Escape":
+          if (isOpen) {
+            setIsOpen(false);
+            setActiveIndex(-1);
+            triggerRef.current?.focus();
+          }
+          break;
+      }
+    },
+    [isOpen, setIsOpen, optionsLength, triggerRef],
+  );
+
+  const handleOptionKeyDown = useCallback(
+    (e: React.KeyboardEvent, index: number) => {
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setActiveIndex((prev) => Math.min(prev + 1, optionsLength - 1));
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setActiveIndex((prev) => Math.max(prev - 1, 0));
+          break;
+        case "Home":
+          e.preventDefault();
+          setActiveIndex(0);
+          break;
+        case "End":
+          e.preventDefault();
+          setActiveIndex(optionsLength - 1);
+          break;
+        case "Enter":
+        case " ":
+          e.preventDefault();
+          onSelect(index);
+          setIsOpen(false);
+          setActiveIndex(-1);
+          triggerRef.current?.focus();
+          break;
+        case "Escape":
+          setIsOpen(false);
+          setActiveIndex(-1);
+          triggerRef.current?.focus();
+          break;
+        case "Tab":
+          setIsOpen(false);
+          setActiveIndex(-1);
+          break;
+      }
+    },
+    [onSelect, setIsOpen, optionsLength, triggerRef],
+  );
+
+  return {
+    activeIndex: resolvedActiveIndex,
+    optionRefs,
+    handleTriggerKeyDown,
+    handleOptionKeyDown,
+    resetActiveIndex,
+  };
+}

--- a/apps/web/hooks/useTabsKeyboard.ts
+++ b/apps/web/hooks/useTabsKeyboard.ts
@@ -1,0 +1,47 @@
+import { useRef } from "react";
+
+type TabItem = {
+  key: string;
+};
+
+type UseTabsKeyboardOptions<T extends string> = {
+  tabs: TabItem[];
+  onTabChange: (key: T) => void;
+};
+
+export function useTabsKeyboard<T extends string>({
+  tabs,
+  onTabChange,
+}: UseTabsKeyboardOptions<T>) {
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const handleTabKeyDown = (e: React.KeyboardEvent, index: number) => {
+    let nextIndex: number | null = null;
+
+    switch (e.key) {
+      case "ArrowRight":
+        e.preventDefault();
+        nextIndex = (index + 1) % tabs.length;
+        break;
+      case "ArrowLeft":
+        e.preventDefault();
+        nextIndex = (index - 1 + tabs.length) % tabs.length;
+        break;
+      case "Home":
+        e.preventDefault();
+        nextIndex = 0;
+        break;
+      case "End":
+        e.preventDefault();
+        nextIndex = tabs.length - 1;
+        break;
+    }
+
+    if (nextIndex !== null) {
+      onTabChange(tabs[nextIndex].key as T);
+      tabRefs.current[nextIndex]?.focus();
+    }
+  };
+
+  return { tabRefs, handleTabKeyDown };
+}

--- a/apps/web/hooks/useTabsKeyboard.ts
+++ b/apps/web/hooks/useTabsKeyboard.ts
@@ -1,4 +1,5 @@
 import { useRef } from "react";
+import { KEYBOARD_KEYS } from "@/utils/ui";
 
 type TabItem = {
   key: string;
@@ -19,19 +20,19 @@ export function useTabsKeyboard<T extends string>({
     let nextIndex: number | null = null;
 
     switch (e.key) {
-      case "ArrowRight":
+      case KEYBOARD_KEYS.ARROW_RIGHT:
         e.preventDefault();
         nextIndex = (index + 1) % tabs.length;
         break;
-      case "ArrowLeft":
+      case KEYBOARD_KEYS.ARROW_LEFT:
         e.preventDefault();
         nextIndex = (index - 1 + tabs.length) % tabs.length;
         break;
-      case "Home":
+      case KEYBOARD_KEYS.HOME:
         e.preventDefault();
         nextIndex = 0;
         break;
-      case "End":
+      case KEYBOARD_KEYS.END:
         e.preventDefault();
         nextIndex = tabs.length - 1;
         break;

--- a/apps/web/utils/ui.ts
+++ b/apps/web/utils/ui.ts
@@ -88,6 +88,14 @@ export type TableAlign = (typeof TABLE_ALIGN)[keyof typeof TABLE_ALIGN];
 export const KEYBOARD_KEYS = {
   ENTER: "Enter",
   ESCAPE: "Escape",
+  SPACE: " ",
+  TAB: "Tab",
+  ARROW_UP: "ArrowUp",
+  ARROW_DOWN: "ArrowDown",
+  ARROW_LEFT: "ArrowLeft",
+  ARROW_RIGHT: "ArrowRight",
+  HOME: "Home",
+  END: "End",
 } as const;
 
 export const BROWSER_API = {


### PR DESCRIPTION
# Description

Implements keyboard navigation support for custom dropdown and tab components, including arrow key navigation, Enter/Space activation, and proper focus management.

Closes #500 

## Type of change


- **Dropdown:** Enter/Space open & select, arrows + Home/End in list, Escape closes + focus on trigger, synthetic-click guard after Space/Enter.
- **Tabs:** Arrow keys + Home/End, roving `tabIndex`, 


[screen-capture (19).webm](https://github.com/user-attachments/assets/e5708226-384b-4075-89bc-1f35a1cc61f7)

# Verification
1. **Dropdown:** Tab → trigger → Space → arrows → Enter to choose → Escape to close.
2. **Tabs:** Tab → active tab → arrows to switch  

  - `Home` → jumps to first option
   - `End` → jumps to last option
