### PR TITLE
481: Dashboard pages double-wrap providers — duplicate Lenis, MutationObservers, and RAF loops

### DIFF
--- a/apps/web/app/(pages)/dashboard/creators/page.tsx
+++ b/apps/web/app/(pages)/dashboard/creators/page.tsx
@@ -1,19 +1,10 @@
 import React, { Suspense } from "react";
 import ClientDashboardCreators from "@/components/Feature/Dashboard/ClientDashboardCreators";
-import { ThemeProvider } from "@/providers/themeProvider";
-import { LanguageProvider } from "@/providers/languageProvider";
-import { SmoothScrollProvider } from "@/providers/smoothScrollProvider";
 
 export default function DashboardCreatorsPage() {
   return (
     <Suspense fallback={<div />}>
-      <ThemeProvider>
-        <LanguageProvider>
-          <SmoothScrollProvider>
-            <ClientDashboardCreators />
-          </SmoothScrollProvider>
-        </LanguageProvider>
-      </ThemeProvider>
+      <ClientDashboardCreators />
     </Suspense>
   );
 }

--- a/apps/web/app/(pages)/dashboard/viewer/page.tsx
+++ b/apps/web/app/(pages)/dashboard/viewer/page.tsx
@@ -1,19 +1,10 @@
 import React, { Suspense } from "react";
-import { ThemeProvider } from "@/providers/themeProvider";
-import { LanguageProvider } from "@/providers/languageProvider";
-import { SmoothScrollProvider } from "@/providers/smoothScrollProvider";
 import ClientDashboardViewer from "@/components/Feature/Dashboard/ClientDashboardViewer";
 
 export default function DashboardViewerPage() {
   return (
     <Suspense fallback={<div />}>
-      <ThemeProvider>
-        <LanguageProvider>
-          <SmoothScrollProvider>
-            <ClientDashboardViewer />
-          </SmoothScrollProvider>
-        </LanguageProvider>
-      </ThemeProvider>
+      <ClientDashboardViewer />
     </Suspense>
   );
 }


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #481

## Type of change

- Removed duplicate dashboard provider wrappers already inherited from `RootLayout` to prevent multiple Lenis instances.