### PR TITLE
502 Refactor SEO metadata URL handling into shared utilities

### DIFF
--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+import { getSiteUrl, ROBOTS_GENERATION_CONTEXT } from "@/utils/seo";
+
+const SITE_URL = getSiteUrl(ROBOTS_GENERATION_CONTEXT);
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,21 @@
+import {
+  INDEXABLE_ROUTES,
+  MONTHLY,
+  getSiteUrl,
+  SITEMAP_GENERATION_CONTEXT,
+  WEEkLY,
+} from "@/utils/seo";
+import type { MetadataRoute } from "next";
+
+const SITE_URL = getSiteUrl(SITEMAP_GENERATION_CONTEXT);
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+
+  return INDEXABLE_ROUTES.map((pathname) => ({
+    url: `${SITE_URL}${pathname === "/" ? "" : pathname}`,
+    lastModified: now,
+    changeFrequency: pathname === "/" ? WEEkLY : MONTHLY,
+    priority: pathname === "/" ? 1 : 0.7,
+  }));
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,8 +1,24 @@
 import type { NextConfig } from "next";
+import { getSiteUrl, INDEXABLE_ROUTES, SEO_HEADERS_CONTEXT } from "./utils/seo";
+
+const SITE_URL = getSiteUrl(SEO_HEADERS_CONTEXT);
 
 const nextConfig: NextConfig = {
   compiler: {
     styledComponents: true,
+  },
+  async headers() {
+    return [
+      ...INDEXABLE_ROUTES.map((pathname) => ({
+        source: pathname,
+        headers: [
+          {
+            key: "Link",
+            value: `<${SITE_URL}${pathname === "/" ? "" : pathname}>; rel="canonical"`,
+          },
+        ],
+      })),
+    ];
   },
   images: {
     remotePatterns: [

--- a/apps/web/utils/seo.ts
+++ b/apps/web/utils/seo.ts
@@ -1,0 +1,36 @@
+export const WEEkLY = "weekly";
+export const MONTHLY = "monthly";
+export const TRAILING_SLASH_REGEX = /\/+$/;
+export const SEO_HEADERS_CONTEXT = "SEO headers";
+export const ROBOTS_GENERATION_CONTEXT = "robots generation";
+export const SITEMAP_GENERATION_CONTEXT = "sitemap generation";
+
+export const INDEXABLE_ROUTES = [
+  "/",
+  "/about-kiibee",
+  "/cookie-settings",
+  "/explore",
+  "/explore-creators",
+  "/for-creators",
+  "/how-it-works",
+  "/pricing",
+  "/privacy-policy",
+  "/single-collection",
+  "/single-tutorial",
+  "/subscription",
+  "/support",
+  "/terms-of-service",
+  "/tutorial-videos",
+] as const;
+
+export function getSiteUrl(errorContext: string): string {
+  const rawSiteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? process.env.SITE_URL;
+
+  if (!rawSiteUrl) {
+    throw new Error(
+      `SITE_URL or NEXT_PUBLIC_SITE_URL must be set for ${errorContext}.`,
+    );
+  }
+
+  return rawSiteUrl.replace(TRAILING_SLASH_REGEX, "");
+}


### PR DESCRIPTION
# Description

Refactored SEO-related URL handling into a shared `seo.ts` utility and reused the same indexable route list across `next.config.ts`, `robots.ts`, and `sitemap.ts`. This removes duplicated logic, keeps canonical URLs consistent, and makes future SEO updates easier to maintain.

Fixes #502

## Type of change
