### PR TITLE
#438: About & read more section modal UI

### DIFF
--- a/apps/web/components/Feature/CreateProfileHome/CreatorInfoModal.styles.ts
+++ b/apps/web/components/Feature/CreateProfileHome/CreatorInfoModal.styles.ts
@@ -1,0 +1,94 @@
+import styled from "styled-components";
+
+export const CreatorInfoContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  text-align: left;
+  height: 100%;
+  max-height: 570px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  padding-right: 4px;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+export const CreatorInfoHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 13px;
+`;
+
+export const BodyText = styled.div`
+  white-space: pre-line;
+  margin: 0;
+`;
+
+export const CloseIconButton = styled.button`
+  width: 24px;
+  height: 24px;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+`;
+
+export const SectionTitle = styled.h2`
+  margin: 0 0 11px;
+`;
+
+export const InfoList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+export const LinksList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+`;
+
+export const Section = styled.section`
+  margin-top: 33px;
+`;
+
+export const LinkItem = styled.a`
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: ${({ theme }) => theme.colors.primary.BLACK};
+  text-decoration: none;
+  width: fit-content;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+export const ShareButton = styled.button`
+  display: flex;
+  width: fit-content;
+  align-items: center;
+  gap: 10px;
+  height: 34px;
+  padding: 5px 20px;
+  border: 0;
+  border-radius: 12px;
+  background: ${({ theme }) => theme.colors.primary.GREEN_50};
+  color: ${({ theme }) => theme.colors.primary.BLACK};
+  cursor: pointer;
+  margin-top: 15px;
+`;

--- a/apps/web/components/Feature/CreateProfileHome/CreatorInfoModal.tsx
+++ b/apps/web/components/Feature/CreateProfileHome/CreatorInfoModal.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { CrossIcon } from "@/assets/icons/crossIcon";
+import { FacebookIcon, TwitterIcon } from "@/assets/icons";
+import { ShareIcon } from "@/assets/icons/shareIcon";
+import { GenericModal } from "@/components/UI/Modals";
+import { MonoText } from "@/components/UI/Monotext";
+import COLORS from "@repo/ui/colors";
+import { useTranslation } from "react-i18next";
+import { creatorInfoModalData } from "@/utils/dummyData/profile.data";
+import {
+  CloseIconButton,
+  CreatorInfoContent,
+  CreatorInfoHeader,
+  InfoList,
+  LinkItem,
+  LinksList,
+  SectionTitle,
+  BodyText,
+  Section,
+  ShareButton,
+} from "./CreatorInfoModal.styles";
+
+type CreatorInfoModalProps = {
+  visible: boolean;
+  onClose: () => void;
+};
+
+export default function CreatorInfoModal({
+  visible,
+  onClose,
+}: CreatorInfoModalProps) {
+  const { t } = useTranslation();
+  const title = creatorInfoModalData.name;
+  const body = creatorInfoModalData.description;
+
+  return (
+    <GenericModal
+      visible={visible}
+      onClose={onClose}
+      width="630px"
+      height="570px"
+      padding="30px"
+      borderRadius="8px"
+      showCloseButton={false}
+    >
+      <CreatorInfoContent data-lenis-prevent>
+        <CreatorInfoHeader>
+          <MonoText $use="H4_Medium">{title}</MonoText>
+          <CloseIconButton type="button" onClick={onClose} aria-label="Close">
+            <CrossIcon
+              width={18}
+              height={18}
+              crossColor={COLORS.primary.BLACK}
+            />
+          </CloseIconButton>
+        </CreatorInfoHeader>
+
+        <BodyText>
+          <MonoText $use="Body_Medium">{body}</MonoText>
+        </BodyText>
+
+        <Section>
+          <SectionTitle>
+            <MonoText $use="H5_Medium">
+              {t("createProfileHome.aboutModal.moreInfo")}
+            </MonoText>
+          </SectionTitle>
+          <InfoList>
+            <MonoText $use="Body_Medium">
+              {t("createProfileHome.aboutModal.joined")}{" "}
+              {creatorInfoModalData.joinedDate}
+            </MonoText>
+            <MonoText $use="Body_Medium">
+              {t("createProfileHome.uploads", {
+                count: creatorInfoModalData.uploads,
+              })}
+            </MonoText>
+          </InfoList>
+        </Section>
+
+        <Section>
+          <SectionTitle>
+            <MonoText $use="H5_Medium">
+              {t("createProfileHome.aboutModal.links")}
+            </MonoText>
+          </SectionTitle>
+          <LinksList>
+            <LinkItem href={`https://${creatorInfoModalData.links.facebook}`}>
+              <FacebookIcon
+                width={19}
+                height={19}
+                color={COLORS.primary.BLACK}
+              />
+              <MonoText $use="Body_Medium">
+                {creatorInfoModalData.links.facebook}
+              </MonoText>
+            </LinkItem>
+            <LinkItem href={`https://${creatorInfoModalData.links.twitter}`}>
+              <TwitterIcon
+                width={19}
+                height={19}
+                color={COLORS.primary.BLACK}
+              />
+              <MonoText $use="Body_Medium">
+                {creatorInfoModalData.links.twitter}
+              </MonoText>
+            </LinkItem>
+          </LinksList>
+        </Section>
+
+        <ShareButton type="button" aria-label={t("common.share")}>
+          <ShareIcon width={18} height={18} />
+          <MonoText $use="Body_Medium">{t("common.share")}</MonoText>
+        </ShareButton>
+      </CreatorInfoContent>
+    </GenericModal>
+  );
+}

--- a/apps/web/locals/da.json
+++ b/apps/web/locals/da.json
@@ -51,7 +51,12 @@
     "brandName": "Nana Jacobson",
     "uploads": "{{count}} uploads",
     "title": "Nana Jacobson",
-    "description": "Online kurser og kreative guides til dig, der vil lære nye teknikker, få inspiration og gøre dine idéer mere konkrete."
+    "description": "Online kurser og kreative guides til dig, der vil lære nye teknikker, få inspiration og gøre dine idéer mere konkrete.",
+    "aboutModal": {
+      "moreInfo": "Mere info",
+      "joined": "Tilsluttet",
+      "links": "Links"
+    }
   },
   "auth": {
     "title": "Stedet hvor skabere og støtter mødes",

--- a/apps/web/locals/en.json
+++ b/apps/web/locals/en.json
@@ -51,7 +51,12 @@
     "brandName": "Nana Jacobson",
     "uploads": "{{count}} uploads",
     "title": "Nana Jacobson",
-    "description": "Online courses and creative guides for people who want to learn new techniques, get inspiration, and make their ideas more concrete."
+    "description": "Online courses and creative guides for people who want to learn new techniques, get inspiration, and make their ideas more concrete.",
+    "aboutModal": {
+      "moreInfo": "More info",
+      "joined": "Joined",
+      "links": "Links"
+    }
   },
   "auth": {
     "title": "The place where creators and supporters meet",

--- a/apps/web/utils/dummyData/profile.data.ts
+++ b/apps/web/utils/dummyData/profile.data.ts
@@ -28,3 +28,15 @@ export const viewerProfileData = {
   email: "Lena_Petersen@gmail.com",
   downloads: 15,
 };
+
+export const creatorInfoModalData = {
+  name: "Raul Jones",
+  description:
+    "Online kurser i Kammas Kantine er til dig, der gerne vil lære at få krammet på din krop. Det får du med viden, sundhed, praktiske tips og tricks og fantastiske retter - der er enkle at lave i dit eget køkken.\nSom kostvejleder og professionel formidler serverer jeg viden om sund mad på en forståelig måde - uden dogmer og løftede pegefingre.\nAlt er nøje planlagt, så du kan kramme din krop på kærligste, mest smagfulde vis. \n \n Online kurser i Kammas Kantine er til dig, der gerne vil lære at få krammet på din krop. Det får du med viden, sundhed, praktiske tips og tricks og fantastiske retter - der er enkle at lave i dit eget køkken.\nSom kostvejleder og professionel formidler serverer jeg viden om sund mad på en forståelig måde - uden dogmer og løftede pegefingre.\nAlt er nøje planlagt, så du kan kramme din krop på kærligste, mest smagfulde vis. ",
+  joinedDate: "24th Nov 2023",
+  uploads: 42,
+  links: {
+    facebook: "facebook.com/rauljones",
+    twitter: "twitter.com/rauljones",
+  },
+};


### PR DESCRIPTION
# Description

Adds the About  Read More section modal UI for Layout-1 on the web platform.

Closes #438 

## Type of change

<img width="1920" height="1036" alt="image" src="https://github.com/user-attachments/assets/1c4d252e-61b9-43b7-a1e5-b3c8b47f1ee6" />

<img width="685" height="694" alt="image" src="https://github.com/user-attachments/assets/869e5ad2-826f-40aa-a5e0-4e19c070fb02" />

