### PR TITLE
#474: Logout does not clear auth tokens or call the logout endpoint

### DIFF
--- a/apps/web/components/Feature/Dashboard/ClientDashboardCreators.tsx
+++ b/apps/web/components/Feature/Dashboard/ClientDashboardCreators.tsx
@@ -14,9 +14,8 @@ import CreatorsContents from "../Contents";
 import { GenericModal } from "@/components/UI/Modals";
 import { MonoText } from "@/components/UI/Monotext";
 import { useTranslation } from "react-i18next";
-import { PATHS } from "@/utils/path";
 import UsersContent from "../Users/UsersContent";
-import { useLogout } from "@/hooks/auth/useLogin";
+import { useLogout } from "@/hooks/auth/useLogout";
 import { useAuthSession } from "@/hooks/auth/useAuthSession";
 
 const ROUTABLE_DASHBOARD_VIEWS = new Set<string>([
@@ -36,8 +35,8 @@ export default function ClientDashboardCreators() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const { mutateAsync: logout } = useLogout();
-  const { clearSession, getUser } = useAuthSession();
+  const { logout } = useLogout();
+  const { getUser } = useAuthSession();
 
   const toggleSidebar = useCallback(() => {
     setOpen((p) => !p);
@@ -59,15 +58,8 @@ export default function ClientDashboardCreators() {
 
   const handleConfirmLogout = useCallback(async () => {
     setShowLogoutModal(false);
-    try {
-      await logout();
-    } catch {
-      // Always clear session and redirect even if server logout fails.
-    } finally {
-      clearSession();
-      router.push(PATHS.AUTH_LOGIN);
-    }
-  }, [logout, router, clearSession]);
+    await logout();
+  }, [logout]);
 
   const renderHeader = () => {
     return <DashboardHeader onToggleSidebar={toggleSidebar} />;

--- a/apps/web/components/Feature/Dashboard/ClientDashboardViewer.tsx
+++ b/apps/web/components/Feature/Dashboard/ClientDashboardViewer.tsx
@@ -18,8 +18,7 @@ import {
 import { MonoText } from "@/components/UI/Monotext";
 import { GenericModal } from "@/components/UI/Modals";
 import { useTranslation } from "react-i18next";
-import { PATHS } from "@/utils/path";
-import { useLogout } from "@/hooks/auth/useLogin";
+import { useLogout } from "@/hooks/auth/useLogout";
 import { useAuthSession } from "@/hooks/auth/useAuthSession";
 import ClientViewerBillings from "@/components/Feature/Dashboard/ClientViewerBillings";
 import ClientViewerProfile from "@/components/Feature/Dashboard/ClientViewerProfile";
@@ -42,8 +41,8 @@ export default function ClientDashboardViewer() {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
-  const { mutateAsync: logout } = useLogout();
-  const { clearSession, getUser } = useAuthSession();
+  const { logout } = useLogout();
+  const { getUser } = useAuthSession();
 
   const toggleSidebar = useCallback(() => {
     setOpen((prev) => !prev);
@@ -105,14 +104,8 @@ export default function ClientDashboardViewer() {
 
   const handleConfirmLogout = useCallback(async () => {
     setShowLogoutModal(false);
-    try {
-      await logout();
-    } catch {
-    } finally {
-      clearSession();
-      router.push(PATHS.AUTH_LOGIN);
-    }
-  }, [logout, router, clearSession]);
+    await logout();
+  }, [logout]);
 
   const sectionTitle = useMemo(() => activePage, [activePage]);
 

--- a/apps/web/hooks/auth/useLogin.ts
+++ b/apps/web/hooks/auth/useLogin.ts
@@ -60,5 +60,5 @@ export const getPostLoginPath = (response: LoginResponse) => {
 export const useLogin = () =>
   usePostAPI<LoginResponse, LoginPayload>(API.auth.login);
 
-export const useLogout = () =>
+export const useLogoutMutation = () =>
   usePostAPI<LogoutResponse, void>(API.auth.logout);

--- a/apps/web/hooks/auth/useLogout.ts
+++ b/apps/web/hooks/auth/useLogout.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { PATHS } from "@/utils/path";
+import { useAuthSession } from "@/hooks/auth/useAuthSession";
+import { useLogoutMutation } from "@/hooks/auth/useLogin";
+
+export const useLogout = () => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { clearSession } = useAuthSession();
+  const { mutateAsync: logoutRequest, isPending } = useLogoutMutation();
+
+  const logout = useCallback(async () => {
+    try {
+      await logoutRequest();
+    } catch {
+    } finally {
+      clearSession();
+      queryClient.clear();
+      router.push(PATHS.AUTH_LOGIN);
+    }
+  }, [clearSession, logoutRequest, queryClient, router]);
+
+  return {
+    logout,
+    isPending,
+  };
+};


### PR DESCRIPTION
# Description

Fixes logout flow to call the logout endpoint, clear auth tokens and user data from localStorage, clear cached queries, and redirect users to login from both creator and viewer dashboards.

Closes #474

## Type of change


[screen-capture (2).webm](https://github.com/user-attachments/assets/6bd46751-0781-47d2-91a6-5518ef62a979)
