### PR TITLE
#580 #589: Upload modal on content 

### DIFF
--- a/apps/web/components/Feature/Contents/ContentUploadModal/index.tsx
+++ b/apps/web/components/Feature/Contents/ContentUploadModal/index.tsx
@@ -52,14 +52,9 @@ export default function ContentUploadModal({
     `contents.contentUploadModal.${uploadType}.helperLineTwo`,
   );
 
-  const handleClose = () => {
+  const handleExit = (callback: () => void) => {
     setSelectedFile(null);
-    onClose();
-  };
-
-  const handleBack = () => {
-    setSelectedFile(null);
-    onBack();
+    callback();
   };
 
   const handleSelectFile = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -85,7 +80,7 @@ export default function ContentUploadModal({
   return (
     <GenericModal
       visible={visible}
-      onClose={handleClose}
+      onClose={() => handleExit(onClose)}
       width="670px"
       height="450px"
       padding="20px"
@@ -94,7 +89,7 @@ export default function ContentUploadModal({
       <BackButton
         type="button"
         aria-label={t("common.back", { defaultValue: "Back" })}
-        onClick={handleBack}
+        onClick={() => handleExit(onBack)}
       >
         <BackButtonIcon size={28} strokeWidth={2.5} />
       </BackButton>

--- a/apps/web/components/Feature/Contents/ContentUploadModal/index.tsx
+++ b/apps/web/components/Feature/Contents/ContentUploadModal/index.tsx
@@ -28,8 +28,17 @@ const UPLOAD_CONFIG = {
     extensions: [".mp4", ".mkv", ".mov", ".m4v"],
   },
   audio: {
-    accept: ".mp3,.wav,.aac,.m4a",
-    extensions: [".mp3", ".wav", ".aac", ".m4a"],
+    accept: ".mp3,.m4a,.wav,.wma,.alac,.flac,.ogg,.aac",
+    extensions: [
+      ".mp3",
+      ".m4a",
+      ".wav",
+      ".wma",
+      ".alac",
+      ".flac",
+      ".ogg",
+      ".aac",
+    ],
   },
   pdf: {
     accept: ".pdf",

--- a/apps/web/components/Feature/Contents/ContentUploadModal/index.tsx
+++ b/apps/web/components/Feature/Contents/ContentUploadModal/index.tsx
@@ -23,6 +23,7 @@ import {
   SelectedFileName,
   UploadBody,
   UploadHelperText,
+  UploadHelperTextGroup,
   UploadModalContent,
 } from "./styles";
 
@@ -44,6 +45,9 @@ export default function ContentUploadModal({
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const uploadType = resolveUploadContentType(contentType);
   const uploadConfig = CONTENT_UPLOAD_CONFIG[uploadType];
+  const helperLineOne = t(
+    `contents.contentUploadModal.${uploadType}.helperLineOne`,
+  );
   const helperLineTwo = t(
     `contents.contentUploadModal.${uploadType}.helperLineTwo`,
   );
@@ -132,11 +136,12 @@ export default function ContentUploadModal({
               </GenericButton>
             </ChooseUploadButton>
 
-            <UploadHelperText>
-              {t(`contents.contentUploadModal.${uploadType}.helperLineOne`)}
-              <br />
-              {helperLineTwo || "\u00a0"}
-            </UploadHelperText>
+            <UploadHelperTextGroup>
+              <UploadHelperText>{helperLineOne}</UploadHelperText>
+              {helperLineTwo ? (
+                <UploadHelperText>{helperLineTwo}</UploadHelperText>
+              ) : null}
+            </UploadHelperTextGroup>
           </ContentUploadDropZone>
         </UploadBody>
       </UploadModalContent>

--- a/apps/web/components/Feature/Contents/ContentUploadModal/index.tsx
+++ b/apps/web/components/Feature/Contents/ContentUploadModal/index.tsx
@@ -12,7 +12,11 @@ import {
 } from "@/components/UI/ImageUploadCropModal/styles";
 import { BackButton } from "../ContentTypeModal/styles";
 import { VARIANT } from "@/utils/Constants";
-import type { ContentType } from "@/utils/content";
+import {
+  CONTENT_UPLOAD_CONFIG,
+  resolveUploadContentType,
+  type ContentType,
+} from "@/utils/content";
 import {
   ChooseUploadButton,
   ContentUploadDropZone,
@@ -21,36 +25,6 @@ import {
   UploadHelperText,
   UploadModalContent,
 } from "./styles";
-
-const UPLOAD_CONFIG = {
-  video: {
-    accept: ".mp4,.mkv,.mov,.m4v",
-    extensions: [".mp4", ".mkv", ".mov", ".m4v"],
-  },
-  audio: {
-    accept: ".mp3,.m4a,.wav,.wma,.alac,.flac,.ogg,.aac",
-    extensions: [
-      ".mp3",
-      ".m4a",
-      ".wav",
-      ".wma",
-      ".alac",
-      ".flac",
-      ".ogg",
-      ".aac",
-    ],
-  },
-  pdf: {
-    accept: ".pdf",
-    extensions: [".pdf"],
-  },
-  epub: {
-    accept: ".epub,.mobi,.azw",
-    extensions: [".epub", ".mobi", ".azw"],
-  },
-} as const;
-
-type UploadContentType = keyof typeof UPLOAD_CONFIG;
 
 type ContentUploadModalProps = {
   visible: boolean;
@@ -68,11 +42,8 @@ export default function ContentUploadModal({
   const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const uploadType: UploadContentType =
-    contentType === "audio" || contentType === "pdf" || contentType === "epub"
-      ? contentType
-      : "video";
-  const uploadConfig = UPLOAD_CONFIG[uploadType];
+  const uploadType = resolveUploadContentType(contentType);
+  const uploadConfig = CONTENT_UPLOAD_CONFIG[uploadType];
   const helperLineTwo = t(
     `contents.contentUploadModal.${uploadType}.helperLineTwo`,
   );

--- a/apps/web/components/Feature/Contents/ContentUploadModal/index.tsx
+++ b/apps/web/components/Feature/Contents/ContentUploadModal/index.tsx
@@ -44,6 +44,10 @@ const UPLOAD_CONFIG = {
     accept: ".pdf",
     extensions: [".pdf"],
   },
+  epub: {
+    accept: ".epub,.mobi,.azw",
+    extensions: [".epub", ".mobi", ".azw"],
+  },
 } as const;
 
 type UploadContentType = keyof typeof UPLOAD_CONFIG;
@@ -65,7 +69,9 @@ export default function ContentUploadModal({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const uploadType: UploadContentType =
-    contentType === "audio" || contentType === "pdf" ? contentType : "video";
+    contentType === "audio" || contentType === "pdf" || contentType === "epub"
+      ? contentType
+      : "video";
   const uploadConfig = UPLOAD_CONFIG[uploadType];
   const helperLineTwo = t(
     `contents.contentUploadModal.${uploadType}.helperLineTwo`,

--- a/apps/web/components/Feature/Contents/ContentUploadModal/index.tsx
+++ b/apps/web/components/Feature/Contents/ContentUploadModal/index.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import React, { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { BackButtonIcon } from "@/assets/icons";
+import GenericButton from "@/components/UI/GenericButton";
+import { GenericModal } from "@/components/UI/Modals";
+import {
+  HiddenInput,
+  UploadHint,
+  UploadOrText,
+} from "@/components/UI/ImageUploadCropModal/styles";
+import { BackButton } from "../ContentTypeModal/styles";
+import { VARIANT } from "@/utils/Constants";
+import type { ContentType } from "@/utils/content";
+import {
+  ChooseUploadButton,
+  ContentUploadDropZone,
+  SelectedFileName,
+  UploadBody,
+  UploadHelperText,
+  UploadModalContent,
+} from "./styles";
+
+const UPLOAD_CONFIG = {
+  video: {
+    accept: ".mp4,.mkv,.mov,.m4v",
+    extensions: [".mp4", ".mkv", ".mov", ".m4v"],
+  },
+  audio: {
+    accept: ".mp3,.wav,.aac,.m4a",
+    extensions: [".mp3", ".wav", ".aac", ".m4a"],
+  },
+  pdf: {
+    accept: ".pdf",
+    extensions: [".pdf"],
+  },
+} as const;
+
+type UploadContentType = keyof typeof UPLOAD_CONFIG;
+
+type ContentUploadModalProps = {
+  visible: boolean;
+  contentType: ContentType | null;
+  onBack: () => void;
+  onClose: () => void;
+};
+
+export default function ContentUploadModal({
+  visible,
+  contentType,
+  onBack,
+  onClose,
+}: ContentUploadModalProps) {
+  const { t } = useTranslation();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const uploadType: UploadContentType =
+    contentType === "audio" || contentType === "pdf" ? contentType : "video";
+  const uploadConfig = UPLOAD_CONFIG[uploadType];
+  const helperLineTwo = t(
+    `contents.contentUploadModal.${uploadType}.helperLineTwo`,
+  );
+
+  const handleClose = () => {
+    setSelectedFile(null);
+    onClose();
+  };
+
+  const handleBack = () => {
+    setSelectedFile(null);
+    onBack();
+  };
+
+  const handleSelectFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setSelectedFile(file);
+    event.target.value = "";
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+
+    const file = event.dataTransfer.files?.[0];
+    const isSupportedFile = uploadConfig.extensions.some((extension) =>
+      file?.name.toLowerCase().endsWith(extension),
+    );
+    if (!file || !isSupportedFile) return;
+
+    setSelectedFile(file);
+  };
+
+  return (
+    <GenericModal
+      visible={visible}
+      onClose={handleClose}
+      width="670px"
+      height="450px"
+      padding="20px"
+      borderRadius="20px"
+    >
+      <BackButton
+        type="button"
+        aria-label={t("common.back", { defaultValue: "Back" })}
+        onClick={handleBack}
+      >
+        <BackButtonIcon size={28} strokeWidth={2.5} />
+      </BackButton>
+
+      <UploadModalContent>
+        <UploadBody>
+          <HiddenInput
+            ref={fileInputRef}
+            type="file"
+            accept={uploadConfig.accept}
+            onChange={handleSelectFile}
+          />
+
+          <ContentUploadDropZone
+            onDragOver={(event) => event.preventDefault()}
+            onDrop={handleDrop}
+          >
+            <UploadHint>
+              {selectedFile
+                ? t("contents.contentUploadModal.selectedFile")
+                : t("contents.contentUploadModal.dragFileHere")}
+            </UploadHint>
+
+            {selectedFile ? (
+              <SelectedFileName title={selectedFile.name}>
+                {selectedFile.name}
+              </SelectedFileName>
+            ) : (
+              <UploadOrText>{t("contents.contentUploadModal.or")}</UploadOrText>
+            )}
+
+            <ChooseUploadButton>
+              <GenericButton
+                variant={VARIANT.PRIMARY}
+                minWidth="182px"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {t("contents.contentUploadModal.chooseFile")}
+              </GenericButton>
+            </ChooseUploadButton>
+
+            <UploadHelperText>
+              {t(`contents.contentUploadModal.${uploadType}.helperLineOne`)}
+              <br />
+              {helperLineTwo || "\u00a0"}
+            </UploadHelperText>
+          </ContentUploadDropZone>
+        </UploadBody>
+      </UploadModalContent>
+    </GenericModal>
+  );
+}

--- a/apps/web/components/Feature/Contents/ContentUploadModal/styles.ts
+++ b/apps/web/components/Feature/Contents/ContentUploadModal/styles.ts
@@ -1,0 +1,47 @@
+import { MonoText } from "@/components/UI/Monotext";
+import { UploadDropZone } from "@/components/UI/ImageUploadCropModal/styles";
+import { ModalContent } from "../ContentTypeModal/styles";
+import styled from "styled-components";
+
+export const UploadModalContent = styled(ModalContent)`
+  height: 350px;
+  padding: 52px 24px 28px;
+`;
+
+export const UploadBody = styled.div`
+  width: 100%;
+  max-width: 520px;
+  height: 100%;
+`;
+
+export const ContentUploadDropZone = styled(UploadDropZone)`
+  height: 268px;
+  padding: 28px 20px;
+  border-color: ${({ theme }) => theme.colors.neutral.GRAY_300};
+  gap: 10px;
+`;
+
+export const ChooseUploadButton = styled.div`
+  margin: 4px 0 8px;
+`;
+
+export const SelectedFileName = styled(MonoText).attrs({
+  $use: "Body_Medium",
+})`
+  width: 100%;
+  max-width: 320px;
+  color: ${({ theme }) => theme.colors.primary.BLACK};
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const UploadHelperText = styled(MonoText).attrs({
+  $use: "Body_Medium",
+})`
+  color: ${({ theme }) => theme.colors.neutral.GRAY};
+  line-height: 1.35;
+  text-align: center;
+  min-height: 38px;
+`;

--- a/apps/web/components/Feature/Contents/ContentUploadModal/styles.ts
+++ b/apps/web/components/Feature/Contents/ContentUploadModal/styles.ts
@@ -5,12 +5,12 @@ import styled from "styled-components";
 
 export const UploadModalContent = styled(ModalContent)`
   height: 350px;
-  padding: 52px 24px 28px;
+  padding: 60px 24px 28px;
 `;
 
 export const UploadBody = styled.div`
   width: 100%;
-  max-width: 520px;
+  max-width: 570px;
   height: 100%;
 `;
 

--- a/apps/web/components/Feature/Contents/ContentUploadModal/styles.ts
+++ b/apps/web/components/Feature/Contents/ContentUploadModal/styles.ts
@@ -37,11 +37,18 @@ export const SelectedFileName = styled(MonoText).attrs({
   white-space: nowrap;
 `;
 
+export const UploadHelperTextGroup = styled.div`
+  min-height: 38px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+`;
+
 export const UploadHelperText = styled(MonoText).attrs({
   $use: "Body_Medium",
 })`
   color: ${({ theme }) => theme.colors.neutral.GRAY};
   line-height: 1.35;
   text-align: center;
-  min-height: 38px;
 `;

--- a/apps/web/components/Feature/Contents/index.tsx
+++ b/apps/web/components/Feature/Contents/index.tsx
@@ -21,6 +21,7 @@ import CreateCollectionModal from "./Collections/CreateCollectionModal";
 import ContentTabPanel from "./ContentTabPanel";
 import CouponFlowModals from "./coupon/CouponFlowModals";
 import ContentTypeModal from "./ContentTypeModal";
+import ContentUploadModal from "./ContentUploadModal";
 import { useContentsViewState } from "@/hooks/contents/useContentsViewState";
 import { useContentsDataState } from "@/hooks/contents/useContentsDataState";
 import { useContentsModalFlows } from "@/hooks/contents/useContentsModalFlows";
@@ -139,6 +140,13 @@ export default function CreatorsContents() {
         onClose={contentTypeFlow.close}
         onBack={contentTypeFlow.close}
         onContinue={contentTypeFlow.continueWithType}
+      />
+
+      <ContentUploadModal
+        visible={contentTypeFlow.showContentUploadModal}
+        contentType={contentTypeFlow.selectedContentType}
+        onClose={contentTypeFlow.close}
+        onBack={contentTypeFlow.backToTypeSelect}
       />
 
       <GenericModal

--- a/apps/web/components/Feature/Contents/index.tsx
+++ b/apps/web/components/Feature/Contents/index.tsx
@@ -20,6 +20,7 @@ import DeleteModals from "./CollectionDeleteMobal";
 import CreateCollectionModal from "./Collections/CreateCollectionModal";
 import ContentTabPanel from "./ContentTabPanel";
 import CouponFlowModals from "./coupon/CouponFlowModals";
+import ContentTypeModal from "./ContentTypeModal";
 import { useContentsViewState } from "@/hooks/contents/useContentsViewState";
 import { useContentsDataState } from "@/hooks/contents/useContentsDataState";
 import { useContentsModalFlows } from "@/hooks/contents/useContentsModalFlows";
@@ -53,6 +54,7 @@ export default function CreatorsContents() {
   } = useContentsDataState(selectedCollection);
   const {
     createCollectionFlow,
+    contentTypeFlow,
     couponForm,
     setCouponForm,
     isCouponSuccess,
@@ -65,7 +67,7 @@ export default function CreatorsContents() {
     closeDiscardModal,
     handleCreateClick,
     handleEditCollection,
-  } = useContentsModalFlows(activeTab, collections);
+  } = useContentsModalFlows(activeTab, collections, isCollectionContentMode);
 
   return (
     <PageShell>
@@ -130,6 +132,13 @@ export default function CreatorsContents() {
         onChangeCollectionName={createCollectionFlow.setCollectionName}
         onClose={createCollectionFlow.closeCreate}
         onConfirm={createCollectionFlow.completeCreate}
+      />
+
+      <ContentTypeModal
+        visible={contentTypeFlow.showContentTypeModal}
+        onClose={contentTypeFlow.close}
+        onBack={contentTypeFlow.close}
+        onContinue={contentTypeFlow.continueWithType}
       />
 
       <GenericModal

--- a/apps/web/hooks/contents/useContentsModalFlows.ts
+++ b/apps/web/hooks/contents/useContentsModalFlows.ts
@@ -1,17 +1,26 @@
 import { useState } from "react";
 import { CollectionRow, INITIAL_COUPON_FORM } from "@/types/collectionsType";
 import { COLLECTIONS, COUPONS, ContentTab } from "@/utils/common";
-import { COUPON_STEPS, CouponStep, STEP_ORDER } from "@/utils/content";
+import {
+  COUPON_STEPS,
+  CouponStep,
+  STEP_ORDER,
+  type ContentType,
+} from "@/utils/content";
 
 export const useContentsModalFlows = (
   activeTab: ContentTab,
   collections: CollectionRow[],
+  isCollectionContentMode: boolean,
 ) => {
   const [showDiscardModal, setShowDiscardModal] = useState(false);
   const [couponForm, setCouponForm] = useState(INITIAL_COUPON_FORM);
   const [isCouponSuccess, setIsCouponSuccess] = useState(false);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showSuccessModal, setShowSuccessModal] = useState(false);
+  const [showContentTypeModal, setShowContentTypeModal] = useState(false);
+  const [selectedContentType, setSelectedContentType] =
+    useState<ContentType | null>(null);
   const [collectionName, setCollectionName] = useState("");
   const [couponStep, setCouponStep] = useState<CouponStep | null>(null);
   const [editingCollectionId, setEditingCollectionId] = useState<string | null>(
@@ -71,6 +80,20 @@ export const useContentsModalFlows = (
     openSuccess: () => setShowSuccessModal(true),
   };
 
+  const contentTypeFlow = {
+    showContentTypeModal,
+    selectedContentType,
+    open: () => setShowContentTypeModal(true),
+    close: () => {
+      setShowContentTypeModal(false);
+      setSelectedContentType(null);
+    },
+    continueWithType: (contentType: ContentType) => {
+      setSelectedContentType(contentType);
+      setShowContentTypeModal(false);
+    },
+  };
+
   const closeCouponFlow = () => {
     setCouponForm(INITIAL_COUPON_FORM);
     setIsCouponSuccess(false);
@@ -96,6 +119,10 @@ export const useContentsModalFlows = (
       return;
     }
     if (activeTab === COLLECTIONS) {
+      if (isCollectionContentMode) {
+        contentTypeFlow.open();
+        return;
+      }
       createCollectionFlow.openCreate();
     }
   };
@@ -108,6 +135,7 @@ export const useContentsModalFlows = (
 
   return {
     createCollectionFlow,
+    contentTypeFlow,
     couponForm,
     setCouponForm,
     isCouponSuccess,

--- a/apps/web/hooks/contents/useContentsModalFlows.ts
+++ b/apps/web/hooks/contents/useContentsModalFlows.ts
@@ -4,11 +4,10 @@ import { COLLECTIONS, COUPONS, ContentTab } from "@/utils/common";
 import {
   COUPON_STEPS,
   CouponStep,
+  isUploadContentType,
   STEP_ORDER,
   type ContentType,
 } from "@/utils/content";
-
-const UPLOAD_CONTENT_TYPES: ContentType[] = ["video", "audio", "pdf", "epub"];
 
 export const useContentsModalFlows = (
   activeTab: ContentTab,
@@ -100,7 +99,7 @@ export const useContentsModalFlows = (
     continueWithType: (contentType: ContentType) => {
       setSelectedContentType(contentType);
       setShowContentTypeModal(false);
-      if (UPLOAD_CONTENT_TYPES.includes(contentType)) {
+      if (isUploadContentType(contentType)) {
         setShowContentUploadModal(true);
         return;
       }

--- a/apps/web/hooks/contents/useContentsModalFlows.ts
+++ b/apps/web/hooks/contents/useContentsModalFlows.ts
@@ -8,7 +8,7 @@ import {
   type ContentType,
 } from "@/utils/content";
 
-const UPLOAD_CONTENT_TYPES: ContentType[] = ["video", "audio", "pdf"];
+const UPLOAD_CONTENT_TYPES: ContentType[] = ["video", "audio", "pdf", "epub"];
 
 export const useContentsModalFlows = (
   activeTab: ContentTab,

--- a/apps/web/hooks/contents/useContentsModalFlows.ts
+++ b/apps/web/hooks/contents/useContentsModalFlows.ts
@@ -8,6 +8,8 @@ import {
   type ContentType,
 } from "@/utils/content";
 
+const UPLOAD_CONTENT_TYPES: ContentType[] = ["video", "audio", "pdf"];
+
 export const useContentsModalFlows = (
   activeTab: ContentTab,
   collections: CollectionRow[],
@@ -19,6 +21,7 @@ export const useContentsModalFlows = (
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [showContentTypeModal, setShowContentTypeModal] = useState(false);
+  const [showContentUploadModal, setShowContentUploadModal] = useState(false);
   const [selectedContentType, setSelectedContentType] =
     useState<ContentType | null>(null);
   const [collectionName, setCollectionName] = useState("");
@@ -82,15 +85,27 @@ export const useContentsModalFlows = (
 
   const contentTypeFlow = {
     showContentTypeModal,
+    showContentUploadModal,
     selectedContentType,
     open: () => setShowContentTypeModal(true),
     close: () => {
       setShowContentTypeModal(false);
+      setShowContentUploadModal(false);
       setSelectedContentType(null);
+    },
+    backToTypeSelect: () => {
+      setShowContentUploadModal(false);
+      setShowContentTypeModal(true);
     },
     continueWithType: (contentType: ContentType) => {
       setSelectedContentType(contentType);
       setShowContentTypeModal(false);
+      if (UPLOAD_CONTENT_TYPES.includes(contentType)) {
+        setShowContentUploadModal(true);
+        return;
+      }
+
+      setShowContentUploadModal(false);
     },
   };
 

--- a/apps/web/locals/da.json
+++ b/apps/web/locals/da.json
@@ -1352,7 +1352,11 @@
         "helperLineTwo": ""
       },
       "pdf": {
-        "helperLineOne": "Max. file size of 100MB of file types (.pdf)",
+        "helperLineOne": "Max. file size of 2GB of file types (.pdf)",
+        "helperLineTwo": ""
+      },
+      "epub": {
+        "helperLineOne": "Max. file size of 2GB of file types (.epub,.mobi,.azw)",
         "helperLineTwo": ""
       }
     },

--- a/apps/web/locals/da.json
+++ b/apps/web/locals/da.json
@@ -1348,7 +1348,7 @@
         "helperLineTwo": "Min. resolution 1080p HD"
       },
       "audio": {
-        "helperLineOne": "Max. file size of 500MB of file types (.mp3,.wav,.aac,.m4a)",
+        "helperLineOne": "Max. file size of 2GB of file types (.mp3,.m4a,.wav,.wma,.alac,.flac,.ogg,.aac)",
         "helperLineTwo": ""
       },
       "pdf": {

--- a/apps/web/locals/da.json
+++ b/apps/web/locals/da.json
@@ -1327,36 +1327,36 @@
       }
     },
     "contentTypeModal": {
-      "title": "Choose the type of content you want to add",
-      "subtitle": "Select a format to continue.",
-      "continue": "Continue",
+      "title": "Vælg den type indhold, du vil tilføje",
+      "subtitle": "Vælg et format for at fortsætte.",
+      "continue": "Fortsæt",
       "options": {
         "video": "Video",
-        "audio": "Audio",
+        "audio": "Lyd",
         "pdf": "PDF",
         "epub": "EPUB",
         "web": "Web"
       }
     },
     "contentUploadModal": {
-      "dragFileHere": "Drag & drop here",
-      "or": "or",
-      "chooseFile": "Choose to upload",
-      "selectedFile": "Selected file",
+      "dragFileHere": "Træk og slip her",
+      "or": "eller",
+      "chooseFile": "Vælg til upload",
+      "selectedFile": "Valgt fil",
       "video": {
-        "helperLineOne": "Max. file size of 2GB of file types (.mp4,.mkv,.mov,.m4v)",
-        "helperLineTwo": "Min. resolution 1080p HD"
+        "helperLineOne": "Maks. filstørrelse er 2 GB for filtyperne (.mp4,.mkv,.mov,.m4v)",
+        "helperLineTwo": "Min. opløsning 1080p HD"
       },
       "audio": {
-        "helperLineOne": "Max. file size of 2GB of file types (.mp3,.m4a,.wav,.wma,.alac,.flac,.ogg,.aac)",
+        "helperLineOne": "Maks. filstørrelse er 2 GB for filtyperne (.mp3,.m4a,.wav,.wma,.alac,.flac,.ogg,.aac)",
         "helperLineTwo": ""
       },
       "pdf": {
-        "helperLineOne": "Max. file size of 2GB of file types (.pdf)",
+        "helperLineOne": "Maks. filstørrelse er 2 GB for filtyperne (.pdf)",
         "helperLineTwo": ""
       },
       "epub": {
-        "helperLineOne": "Max. file size of 2GB of file types (.epub,.mobi,.azw)",
+        "helperLineOne": "Maks. filstørrelse er 2 GB for filtyperne (.epub,.mobi,.azw)",
         "helperLineTwo": ""
       }
     },

--- a/apps/web/locals/da.json
+++ b/apps/web/locals/da.json
@@ -1338,6 +1338,24 @@
         "web": "Web"
       }
     },
+    "contentUploadModal": {
+      "dragFileHere": "Drag & drop here",
+      "or": "or",
+      "chooseFile": "Choose to upload",
+      "selectedFile": "Selected file",
+      "video": {
+        "helperLineOne": "Max. file size of 2GB of file types (.mp4,.mkv,.mov,.m4v)",
+        "helperLineTwo": "Min. resolution 1080p HD"
+      },
+      "audio": {
+        "helperLineOne": "Max. file size of 500MB of file types (.mp3,.wav,.aac,.m4a)",
+        "helperLineTwo": ""
+      },
+      "pdf": {
+        "helperLineOne": "Max. file size of 100MB of file types (.pdf)",
+        "helperLineTwo": ""
+      }
+    },
     "deleteModal": {
       "title": "Delete content?",
       "message": "Are you sure you want to delete this content? This action cannot be undone.",

--- a/apps/web/locals/en.json
+++ b/apps/web/locals/en.json
@@ -1352,7 +1352,11 @@
         "helperLineTwo": ""
       },
       "pdf": {
-        "helperLineOne": "Max. file size of 100MB of file types (.pdf)",
+        "helperLineOne": "Max. file size of 2GB of file types (.pdf)",
+        "helperLineTwo": ""
+      },
+      "epub": {
+        "helperLineOne": "Max. file size of 2GB of file types (.epub,.mobi,.azw)",
         "helperLineTwo": ""
       }
     },

--- a/apps/web/locals/en.json
+++ b/apps/web/locals/en.json
@@ -1348,7 +1348,7 @@
         "helperLineTwo": "Min. resolution 1080p HD"
       },
       "audio": {
-        "helperLineOne": "Max. file size of 500MB of file types (.mp3,.wav,.aac,.m4a)",
+        "helperLineOne": "Max. file size of 2GB of file types (.mp3,.m4a,.wav,.wma,.alac,.flac,.ogg,.aac)",
         "helperLineTwo": ""
       },
       "pdf": {

--- a/apps/web/locals/en.json
+++ b/apps/web/locals/en.json
@@ -1338,6 +1338,24 @@
         "web": "Web"
       }
     },
+    "contentUploadModal": {
+      "dragFileHere": "Drag & drop here",
+      "or": "or",
+      "chooseFile": "Choose to upload",
+      "selectedFile": "Selected file",
+      "video": {
+        "helperLineOne": "Max. file size of 2GB of file types (.mp4,.mkv,.mov,.m4v)",
+        "helperLineTwo": "Min. resolution 1080p HD"
+      },
+      "audio": {
+        "helperLineOne": "Max. file size of 500MB of file types (.mp3,.wav,.aac,.m4a)",
+        "helperLineTwo": ""
+      },
+      "pdf": {
+        "helperLineOne": "Max. file size of 100MB of file types (.pdf)",
+        "helperLineTwo": ""
+      }
+    },
 
     "deleteModal": {
       "title": "Delete content?",

--- a/apps/web/utils/content.ts
+++ b/apps/web/utils/content.ts
@@ -22,6 +22,53 @@ export type ContentTypeOption = {
   Icon: IconComponent;
 };
 
+export const UPLOAD_CONTENT_TYPES = ["video", "audio", "pdf", "epub"] as const;
+
+export type UploadContentType = (typeof UPLOAD_CONTENT_TYPES)[number];
+
+export const CONTENT_UPLOAD_CONFIG: Record<
+  UploadContentType,
+  { accept: string; extensions: readonly string[] }
+> = {
+  video: {
+    accept: ".mp4,.mkv,.mov,.m4v",
+    extensions: [".mp4", ".mkv", ".mov", ".m4v"],
+  },
+  audio: {
+    accept: ".mp3,.m4a,.wav,.wma,.alac,.flac,.ogg,.aac",
+    extensions: [
+      ".mp3",
+      ".m4a",
+      ".wav",
+      ".wma",
+      ".alac",
+      ".flac",
+      ".ogg",
+      ".aac",
+    ],
+  },
+  pdf: {
+    accept: ".pdf",
+    extensions: [".pdf"],
+  },
+  epub: {
+    accept: ".epub,.mobi,.azw",
+    extensions: [".epub", ".mobi", ".azw"],
+  },
+} as const;
+
+export const isUploadContentType = (
+  contentType: ContentType,
+): contentType is UploadContentType =>
+  UPLOAD_CONTENT_TYPES.includes(contentType as UploadContentType);
+
+export const resolveUploadContentType = (
+  contentType: ContentType | null,
+): UploadContentType => {
+  if (!contentType) return "video";
+  return isUploadContentType(contentType) ? contentType : "video";
+};
+
 export const CONTENT_TYPE_OPTIONS: readonly ContentTypeOption[] = [
   {
     key: "video",


### PR DESCRIPTION
# Description

Adds an upload modal to the content section for uploading content.

Closes #580
Closes #589

## Type of change

<img width="1920" height="1041" alt="image" src="https://github.com/user-attachments/assets/f5b540b5-ec37-4797-b7a6-70b00dc9c37c" />
 
<img width="752" height="520" alt="image" src="https://github.com/user-attachments/assets/f77b8ec8-d49f-48f8-a155-78919071b29d" />

<img width="761" height="530" alt="image" src="https://github.com/user-attachments/assets/c2ed0cc7-9ca3-4fb7-b8d8-954e431c80c5" />

<img width="755" height="531" alt="image" src="https://github.com/user-attachments/assets/75ec82b3-4f30-4834-9d09-586882af0a2c" />
 
