### PR TITLE
#625 BUGS: Pricing FAQ entries show identical answers

### DIFF
--- a/apps/web/locals/da.json
+++ b/apps/web/locals/da.json
@@ -823,15 +823,15 @@
     "items": [
       {
         "question": "Can I sell content with the free plan?",
-        "answer": "Yes, you can sell a limited number of items. Upgrade anytime to access advanced features and unlimited uploads."
+        "answer": "Yes. The free Launch plan lets you upload and sell up to two products with no monthly cost. It’s a great way to test your idea before upgrading."
       },
       {
         "question": "Can I change or cancel my plan?",
-        "answer": "Yes, you can sell a limited number of items. Upgrade anytime to access advanced features and unlimited uploads."
+        "answer": "Absolutely. You can upgrade, downgrade, or cancel your subscription at any time directly from your account settings."
       },
       {
         "question": "Do viewers need a subscription?",
-        "answer": "Yes, you can sell a limited number of items. Upgrade anytime to access advanced features and unlimited uploads."
+        "answer": "No. Your customers only pay for the content you choose to sell. They do not need their own subscription to access purchases."
       }
     ]
   },

--- a/apps/web/locals/en.json
+++ b/apps/web/locals/en.json
@@ -823,15 +823,15 @@
     "items": [
       {
         "question": "Can I sell content with the free plan?",
-        "answer": "Yes, you can sell a limited number of items. Upgrade anytime to access advanced features and unlimited uploads."
+        "answer": "Yes. The free Launch plan lets you upload and sell up to two products with no monthly cost. It’s a great way to test your idea before upgrading."
       },
       {
         "question": "Can I change or cancel my plan?",
-        "answer": "Yes, you can sell a limited number of items. Upgrade anytime to access advanced features and unlimited uploads."
+        "answer": "Absolutely. You can upgrade, downgrade, or cancel your subscription at any time directly from your account settings."
       },
       {
         "question": "Do viewers need a subscription?",
-        "answer": "Yes, you can sell a limited number of items. Upgrade anytime to access advanced features and unlimited uploads."
+        "answer": "No. Your customers only pay for the content you choose to sell. They do not need their own subscription to access purchases."
       }
     ]
   },


### PR DESCRIPTION

# Description
I have fix Pricing FAQ entries show identical answers

Fixes #625 

## Type of change
<img width="936" height="683" alt="image" src="https://github.com/user-attachments/assets/517fd304-0637-4d79-b49a-a7c8973b61b3" />
