### PR TITLE
#629: Explore creators dropdown menu items are hard to read

### DIFF
--- a/apps/web/components/Layout/Navbar/styles.ts
+++ b/apps/web/components/Layout/Navbar/styles.ts
@@ -107,8 +107,11 @@ export const MegaMenu = styled.div`
   left: 0;
   width: 100%;
   padding: 1.5rem 0;
-  background: ${({ theme }) => theme.colors.primary.WHITE_10};
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(28px);
+  background: ${({ theme }) => theme.colors.primary.WHITE_80};
+  transition:
+    background 180ms ease,
+    backdrop-filter 180ms ease;
   box-shadow: 0 6px 24px ${({ theme }) => theme.colors.neutral.GRAY_300};
   pointer-events: auto;
   z-index: 1000;

--- a/packages/ui/src/colors.ts
+++ b/packages/ui/src/colors.ts
@@ -6,6 +6,7 @@ export interface ColorPalette {
     WHITE_10: string;
     WHITE_90: string;
     WHITE_18: string;
+    WHITE_80: string;
     BLACK: string;
     BLACK_90: string;
     GREEN: string;
@@ -87,6 +88,7 @@ export const COLORS: ColorPalette = {
     WHITE_10: "rgba(255,255,255,0.1)",
     WHITE_90: "rgba(255,255,255,0.9)",
     WHITE_18: "rgba(255,255,255,0.18)",
+    WHITE_80: "rgba(255,255,255,0.8)",
     BLACK: "rgb(0,0,0)",
     BLACK_90: "rgba(0,0,0,0.9)",
     GREEN: "rgb(83,186,169)",


### PR DESCRIPTION
# Description

Improves the readability of Explore Creators dropdown menu items.

Closes #629

## Type of change

# Before: 
<img width="1920" height="1043" alt="image" src="https://github.com/user-attachments/assets/a8f7ae54-1e2c-4b7e-a1cd-d3e3c6b7c72a" />


# After
<img width="1919" height="1043" alt="image" src="https://github.com/user-attachments/assets/e8d80063-1b40-41e9-a759-fe91ccec8339" />
