### PR TITLE
#409: Show valid errors on login & signup froms

### DIFF
--- a/apps/web/hooks/auth/useViewerSignUpForm.ts
+++ b/apps/web/hooks/auth/useViewerSignUpForm.ts
@@ -89,6 +89,12 @@ export function useViewerSignUpForm() {
         password: values.password,
         confirmPassword: values.repeatPassword,
       });
+
+      if (response.success === false) {
+        setFormError(response.message || t("viewerSignup.form.signupFailed"));
+        return;
+      }
+
       setSession(response);
       router.push(PATHS.AUTH_SIGNUP_VIEWER_PREFERENCES);
     } catch (error) {


### PR DESCRIPTION
# Description

Shows valid error messages on login and signup forms.

Closes #409

## Type of change

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/222472fe-f075-448a-ab69-65745562cd86" />
