### PR TITLE
722: Consolidate duplicate FilterSectionKey type definition in filters.ts & exportCreators.ts

### DIFF
--- a/apps/web/components/Feature/ExploreCreators/Hero/CreatorsFilters/index.tsx
+++ b/apps/web/components/Feature/ExploreCreators/Hero/CreatorsFilters/index.tsx
@@ -29,12 +29,9 @@ import {
   OptionText,
   SectionIcon,
 } from "../styles";
-import {
-  CreatorFiltersControlProps,
-  FilterSectionKey,
-  OptionItem,
-} from "@/types/exportCreators";
+import { CreatorFiltersControlProps, OptionItem } from "@/types/exportCreators";
 import { BUTTON } from "@/utils/Constants";
+import { FilterSectionKey } from "@/types/filters";
 
 function CreatorFiltersControl({
   refs,

--- a/apps/web/components/Feature/ExploreCreators/Hero/index.tsx
+++ b/apps/web/components/Feature/ExploreCreators/Hero/index.tsx
@@ -9,7 +9,6 @@ import { DEFAULT_SORT, SORT_OPTIONS, SortValue } from "@/utils/sortOptions";
 import { KEYBOARD_KEYS } from "@/utils/ui";
 import { CREATORS } from "@/utils/translationKeys";
 import CreatorFiltersControl from "./CreatorsFilters";
-import type { FilterSectionKey } from "@/types/exportCreators";
 import { Hero, HeroTitleText, Inner, Content, Title, Controls } from "./styles";
 import { useCreatorFilters } from "@/hooks/useCreatorFilters";
 import {
@@ -17,7 +16,7 @@ import {
   CREATOR_OPTIONS,
   FORMAT_OPTION_KEYS,
 } from "@/utils/creatorFilters";
-import { ExploreCreatorsHeroProps } from "@/types/filters";
+import { ExploreCreatorsHeroProps, FilterSectionKey } from "@/types/filters";
 
 export default function ExploreCreatorsHero({
   showControls = true,

--- a/apps/web/types/exportCreators.ts
+++ b/apps/web/types/exportCreators.ts
@@ -1,6 +1,7 @@
 import React from "react";
 import { FilterGroupKey } from "@/utils/creatorFilters";
 import { TFunction } from "i18next";
+import { FilterSectionKey } from "./filters";
 
 export type OptionItem = {
   key: string;
@@ -16,12 +17,9 @@ export const PRICE_RANGE_FIELDS = {
   MAX: "max",
 } as const;
 
-export type FilterPanelSectionKey =
-  (typeof FILTER_PANEL_SECTIONS)[keyof typeof FILTER_PANEL_SECTIONS];
 export type PriceRangeFieldKey =
   (typeof PRICE_RANGE_FIELDS)[keyof typeof PRICE_RANGE_FIELDS];
 
-export type FilterSectionKey = FilterGroupKey | FilterPanelSectionKey;
 export type CreatorFiltersControlRefs = {
   filterButtonRef: React.RefObject<HTMLButtonElement | null>;
   filterOverlayRef: React.RefObject<HTMLDivElement | null>;


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #722

## Type of change

- Removed duplicate `FilterSectionKey` definitions and kept a single source of truth in types/filters.ts, then re-exported it from types/exportCreators.ts to unify all imports.