### PR TITLE
725: Extract shared success UI pattern into reusable SuccessModalIcon component 

### DIFF
--- a/apps/web/components/Feature/Contents/CollectionDeleteMobal.tsx
+++ b/apps/web/components/Feature/Contents/CollectionDeleteMobal.tsx
@@ -1,7 +1,6 @@
 import { GenericModal } from "@/components/UI/Modals";
-import { SuccessArcIcon } from "@/assets/icons";
-import COLORS from "@repo/ui/colors";
 import { useTranslation } from "react-i18next";
+import SuccessModalIcon from "@/components/UI/Modals/SuccessModalIcon";
 
 type DeleteModalsProps = {
   showDeleteConfirm: boolean;
@@ -37,13 +36,7 @@ export default function DeleteModals({
 
       <GenericModal
         visible={showDeleteSuccess}
-        icon={
-          <SuccessArcIcon
-            width={40}
-            height={40}
-            color={COLORS.primary.GREEN_200}
-          />
-        }
+        icon={<SuccessModalIcon />}
         title={t("contents.deleteSuccessModal.title")}
         message={t("contents.deleteSuccessModal.message")}
         confirmLabel={t("contents.deleteSuccessModal.done")}

--- a/apps/web/components/Feature/Contents/coupon/CouponPreviewModal/index.tsx
+++ b/apps/web/components/Feature/Contents/coupon/CouponPreviewModal/index.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { BackButtonIcon, SuccessArcIcon } from "@/assets/icons";
+import { BackButtonIcon } from "@/assets/icons";
 import { GenericModal } from "@/components/UI/Modals";
 import {
   BackButton,
@@ -27,9 +27,9 @@ import {
   UploadList,
 } from "./styles";
 import { COUPON_DISCOUNT_PERCENTAGE } from "@/utils/common";
-import COLORS from "@repo/ui/colors";
 import { MonoText } from "@/components/UI/Monotext";
 import { BUTTON } from "@/utils/Constants";
+import SuccessModalIcon from "@/components/UI/Modals/SuccessModalIcon";
 
 type Props = {
   visible: boolean;
@@ -140,11 +140,7 @@ export default function CouponPreviewModal({
         )}
         {isSuccess && (
           <UploadList>
-            <SuccessArcIcon
-              width={40}
-              height={40}
-              color={COLORS.primary.GREEN_200}
-            />
+            <SuccessModalIcon />
             <MonoText $use="H5_Medium">
               {t("contents.couponPreview.uploading")}
             </MonoText>

--- a/apps/web/components/Feature/Contents/index.tsx
+++ b/apps/web/components/Feature/Contents/index.tsx
@@ -3,7 +3,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { GenericModal } from "@/components/UI/Modals";
-import COLORS from "@repo/ui/colors";
 import {
   ContentPanel,
   ContentsScrollArea,
@@ -13,7 +12,6 @@ import {
   PageShell,
   Title,
 } from "./styles";
-import { SuccessArcIcon } from "@/assets/icons";
 import ContentsHeaderAction from "./ContentsHeaderAction";
 import GenericTabs from "@/components/UI/GenericTabs";
 import { CONTENTS as CONTENTS_KEYS } from "@/utils/translationKeys";
@@ -27,6 +25,7 @@ import ContentUploadModal from "./ContentUploadModal";
 import { useContentsViewState } from "@/hooks/contents/useContentsViewState";
 import { useContentsDataState } from "@/hooks/contents/useContentsDataState";
 import { useContentsModalFlows } from "@/hooks/contents/useContentsModalFlows";
+import SuccessModalIcon from "@/components/UI/Modals/SuccessModalIcon";
 
 export default function CreatorsContents() {
   const { t } = useTranslation();
@@ -160,13 +159,7 @@ export default function CreatorsContents() {
 
       <GenericModal
         visible={createCollectionFlow.showSuccessModal}
-        icon={
-          <SuccessArcIcon
-            width={40}
-            height={40}
-            color={COLORS.primary.GREEN_200}
-          />
-        }
+        icon={<SuccessModalIcon />}
         iconMargin="0 auto 8px"
         title={t("contents.createCollectionSuccessModal.title")}
         message={t("contents.createCollectionSuccessModal.message")}

--- a/apps/web/components/Feature/Dashboard/ClientViewerBillings/AddCardModal.tsx
+++ b/apps/web/components/Feature/Dashboard/ClientViewerBillings/AddCardModal.tsx
@@ -5,12 +5,12 @@ import { GenericModal } from "@/components/UI/Modals";
 import InputField from "@/components/UI/InputFields";
 import { INPUT_TYPE, MODAL_ALIGN } from "@/utils/ui";
 import { INPUT_VARIANTS } from "@/utils/Constants";
-import { CardIcon, SuccessArcIcon } from "@/assets/icons";
+import { CardIcon } from "@/assets/icons";
 import { useAddCard } from "@/hooks/useAddCard";
 import { Container, ErrorText, FieldWrapper, Grid } from "./styles";
 import { DASHBOARD_VIEWER_BILLINGS } from "@/utils/translationKeys";
 import { useTranslation } from "react-i18next";
-import COLORS from "@repo/ui/colors";
+import SuccessModalIcon from "@/components/UI/Modals/SuccessModalIcon";
 
 type AddCardModalProps = {
   visible: boolean;
@@ -128,13 +128,7 @@ export default function AddCardModal({ visible, onClose }: AddCardModalProps) {
 
       <GenericModal
         visible={successOpen}
-        icon={
-          <SuccessArcIcon
-            width={40}
-            height={40}
-            color={COLORS.primary.GREEN_200}
-          />
-        }
+        icon={<SuccessModalIcon />}
         title={t(
           DASHBOARD_VIEWER_BILLINGS.paymentMethods.addCardModal.successTitle,
         )}

--- a/apps/web/components/Feature/Dashboard/ClientViewerProfile/index.tsx
+++ b/apps/web/components/Feature/Dashboard/ClientViewerProfile/index.tsx
@@ -23,7 +23,6 @@ import { MODAL_ALIGN } from "@/utils/ui";
 import { CREATOR_PROFILE } from "@/utils/translationKeys";
 import PasswordSection from "../CreatorProfile/PasswordSection";
 import { useViewerProfile } from "@/hooks/useViewerProfile";
-import { SuccessArcIcon } from "@/assets/icons";
 import { QuestionIcon } from "@/assets/icons/questionIcon";
 import { useRouter } from "next/navigation";
 import { VIEWER_PROFILE_FIELDS } from "@/utils/profile";
@@ -34,6 +33,7 @@ import {
   forgotPwIsError,
   forgotPwIsSuccess,
 } from "@/utils/viewerProfile";
+import SuccessModalIcon from "@/components/UI/Modals/SuccessModalIcon";
 
 export default function ClientViewerProfile() {
   const { t } = useTranslation();
@@ -161,13 +161,7 @@ export default function ClientViewerProfile() {
       </GenericModal>
       <GenericModal
         visible={showProfileSavedModal}
-        icon={
-          <SuccessArcIcon
-            width={40}
-            height={40}
-            color={COLORS.primary.GREEN_200}
-          />
-        }
+        icon={<SuccessModalIcon />}
         iconMargin="0 auto 8px"
         textAlign={MODAL_ALIGN.CENTER}
         title={t("dashboard.viewerProfile.saveModalTitle")}
@@ -180,13 +174,7 @@ export default function ClientViewerProfile() {
       />
       <GenericModal
         visible={forgotPwIsSuccess(forgotPwNotice)}
-        icon={
-          <SuccessArcIcon
-            width={40}
-            height={40}
-            color={COLORS.primary.GREEN_200}
-          />
-        }
+        icon={<SuccessModalIcon />}
         iconMargin="0 auto 8px"
         textAlign={MODAL_ALIGN.CENTER}
         title={t("forgotPassword.checkEmailTitle")}
@@ -216,13 +204,7 @@ export default function ClientViewerProfile() {
       />
       <GenericModal
         visible={showPasswordSuccessModal}
-        icon={
-          <SuccessArcIcon
-            width={40}
-            height={40}
-            color={COLORS.primary.GREEN_200}
-          />
-        }
+        icon={<SuccessModalIcon />}
         iconMargin="0 auto 8px"
         textAlign={MODAL_ALIGN.CENTER}
         title={t("creatorProfile.passwordSuccessTitle")}

--- a/apps/web/components/Feature/Dashboard/CreatorProfile/index.tsx
+++ b/apps/web/components/Feature/Dashboard/CreatorProfile/index.tsx
@@ -30,7 +30,6 @@ import { getProfileFields } from "@/utils/creatorProfilefields";
 import { ProfileForm } from "@/utils/creatorProfile";
 import { MODAL_ALIGN } from "@/utils/ui";
 import { GenericModal } from "@/components/UI/Modals";
-import { SuccessArcIcon } from "@/assets/icons";
 import { QuestionIcon } from "@/assets/icons/questionIcon";
 import { useRouter } from "next/navigation";
 import ImageUploader from "./ImageUploader";
@@ -42,6 +41,7 @@ import {
   forgotPwIsError,
   forgotPwIsSuccess,
 } from "@/utils/viewerProfile";
+import SuccessModalIcon from "@/components/UI/Modals/SuccessModalIcon";
 
 export default function CreatorProfile() {
   const { t } = useTranslation();
@@ -182,13 +182,7 @@ export default function CreatorProfile() {
 
       <GenericModal
         visible={forgotPwIsSuccess(forgotPwNotice)}
-        icon={
-          <SuccessArcIcon
-            width={40}
-            height={40}
-            color={COLORS.primary.GREEN_200}
-          />
-        }
+        icon={<SuccessModalIcon />}
         iconMargin="0 auto 8px"
         textAlign={MODAL_ALIGN.CENTER}
         title={t("forgotPassword.checkEmailTitle")}
@@ -219,15 +213,7 @@ export default function CreatorProfile() {
 
       <GenericModal
         visible={showDeleteModal || showDeleteSuccessModal}
-        icon={
-          showDeleteSuccessModal ? (
-            <SuccessArcIcon
-              width={40}
-              height={40}
-              color={COLORS.primary.GREEN_200}
-            />
-          ) : undefined
-        }
+        icon={showDeleteSuccessModal ? <SuccessModalIcon /> : undefined}
         iconMargin={showDeleteSuccessModal ? "0 auto 8px" : undefined}
         title={
           showDeleteSuccessModal
@@ -265,13 +251,7 @@ export default function CreatorProfile() {
       />
       <GenericModal
         visible={showPasswordSuccessModal}
-        icon={
-          <SuccessArcIcon
-            width={40}
-            height={40}
-            color={COLORS.primary.GREEN_200}
-          />
-        }
+        icon={<SuccessModalIcon />}
         iconMargin="0 auto 8px"
         title={t("creatorProfile.passwordSuccessTitle")}
         message={t("creatorProfile.passwordSuccessMessage")}

--- a/apps/web/components/Feature/Settings/Export/index.tsx
+++ b/apps/web/components/Feature/Settings/Export/index.tsx
@@ -11,8 +11,8 @@ import GenericButton from "@/components/UI/GenericButton";
 import { VARIANT } from "@/utils/Constants";
 import COLORS from "@repo/ui/colors";
 import { EXPORT_TYPE_OPTIONS } from "@/utils/exportOptions";
-import { SuccessArcIcon } from "@/assets/icons";
 import { GenericModal } from "@/components/UI/Modals";
+import SuccessModalIcon from "@/components/UI/Modals/SuccessModalIcon";
 
 export default function ExportContent() {
   const { t } = useTranslation();
@@ -77,13 +77,7 @@ export default function ExportContent() {
       </Section>
       <GenericModal
         visible={showSuccessModal}
-        icon={
-          <SuccessArcIcon
-            width={40}
-            height={40}
-            color={COLORS.primary.GREEN_200}
-          />
-        }
+        icon={<SuccessModalIcon />}
         iconMargin="0 auto 8px"
         title={t(SETTINGS.export.modalTitle)}
         message={t(SETTINGS.export.modalMessage)}

--- a/apps/web/components/Feature/Settings/Notification/notificationModals.tsx
+++ b/apps/web/components/Feature/Settings/Notification/notificationModals.tsx
@@ -1,9 +1,8 @@
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { GenericModal } from "@/components/UI/Modals";
-import { SuccessArcIcon } from "@/assets/icons";
-import COLORS from "@repo/ui/colors";
 import { NOTIFICATION_MODAL, NotificationModalType } from "@/utils/ui";
+import SuccessModalIcon from "@/components/UI/Modals/SuccessModalIcon";
 
 type NotificationModalsProps = {
   modalType: NotificationModalType;
@@ -21,13 +20,7 @@ export default function NotificationModals({
   const modalProps = useMemo(() => {
     if (modalType === NOTIFICATION_MODAL.SUCCESS) {
       return {
-        icon: (
-          <SuccessArcIcon
-            width={40}
-            height={40}
-            color={COLORS.primary.GREEN_200}
-          />
-        ),
+        icon: <SuccessModalIcon />,
         iconMargin: "0 auto 8px",
         title: t("settings.notifications.successModal.title"),
         message: t("settings.notifications.successModal.message"),

--- a/apps/web/components/UI/Modals/SuccessModalIcon.tsx
+++ b/apps/web/components/UI/Modals/SuccessModalIcon.tsx
@@ -1,0 +1,14 @@
+import { SuccessArcIcon } from "@/assets/icons";
+import { COLORS } from "@repo/ui/colors";
+
+type SuccessModalIconProps = {
+  size?: number;
+  color?: string;
+};
+
+export default function SuccessModalIcon({
+  size = 40,
+  color = COLORS.primary.GREEN_200,
+}: SuccessModalIconProps) {
+  return <SuccessArcIcon width={size} height={size} color={color} />;
+}


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #725

## Type of change

- Created a reusable `SuccessModalIcon` component and replaced all repeated `<SuccessArcIcon />` usages with it to remove duplicate props and centralize default styling.