### PR TITLE
#717: Inconsistent profile sub-routes (only Layout2 has /about)

### DIFF
--- a/apps/web/app/(pages)/create-profile1/about/page.tsx
+++ b/apps/web/app/(pages)/create-profile1/about/page.tsx
@@ -1,0 +1,12 @@
+import CreateProfile1Layout from "@/components/Layout/CreateProfile1";
+import Hero from "@/components/Feature/ProfileLayout/Layout1/Hero";
+import AboutSection from "@/components/Feature/ProfileLayout/Layout2/About/AboutSection";
+
+export default function AboutPage() {
+  return (
+    <CreateProfile1Layout>
+      <Hero />
+      <AboutSection />
+    </CreateProfile1Layout>
+  );
+}

--- a/apps/web/app/(pages)/create-profile3/about/page.tsx
+++ b/apps/web/app/(pages)/create-profile3/about/page.tsx
@@ -1,0 +1,12 @@
+import CreateProfile1Layout from "@/components/Layout/CreateProfile1";
+import Hero from "@/components/Feature/ProfileLayout/Layout3/Hero";
+import AboutSection from "@/components/Feature/ProfileLayout/Layout2/About/AboutSection";
+
+export default function AboutPage() {
+  return (
+    <CreateProfile1Layout>
+      <Hero />
+      <AboutSection />
+    </CreateProfile1Layout>
+  );
+}

--- a/apps/web/components/Feature/ProfileLayout/Layout1/Hero/index.tsx
+++ b/apps/web/components/Feature/ProfileLayout/Layout1/Hero/index.tsx
@@ -7,6 +7,7 @@ import { SearchIcon } from "@/assets/icons/searchBarIcon";
 import coverImage from "@/assets/images/creators/create_profile_hero1.png";
 import avatarImage from "@/assets/images/creators/profile_pic.png";
 import GenericTabs from "@/components/UI/GenericTabs";
+import { MonoText } from "@/components/UI/Monotext";
 import {
   AvatarImage,
   AvatarWrap,
@@ -28,6 +29,7 @@ import {
 } from "./styles";
 import { HOME, PROFILE_TABS, ProfileTabKey } from "@/utils/common";
 import { CREATE_PROFILE_HOME } from "@/utils/translationKeys";
+import CreatorInfoModal from "../../Layout2/Home/CreatorInfoModal";
 
 export default function Hero() {
   const { t } = useTranslation();
@@ -37,6 +39,7 @@ export default function Hero() {
     PROFILE_TABS.find((tab) => tab.href === pathname)?.key ?? HOME;
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
+  const [isCreatorInfoOpen, setIsCreatorInfoOpen] = useState(false);
 
   const handleTabChange = (tab: ProfileTabKey) => {
     const target = PROFILE_TABS.find((item) => item.key === tab)?.href;
@@ -81,7 +84,14 @@ export default function Hero() {
                 {t(CREATE_PROFILE_HOME.description)}
               </CreatorBioText>
               <MoreText>
-                <MoreTextLabel> {t(CREATE_PROFILE_HOME.more)}</MoreTextLabel>
+                <MoreTextLabel
+                  type="button"
+                  onClick={() => setIsCreatorInfoOpen(true)}
+                >
+                  <MonoText $use="Body_SemiBold">
+                    {t(CREATE_PROFILE_HOME.more)}
+                  </MonoText>
+                </MoreTextLabel>
               </MoreText>
             </CreatorBio>
           </ProfileMeta>
@@ -104,6 +114,11 @@ export default function Hero() {
           />
         </TabsWrapper>
       </ContentInner>
+
+      <CreatorInfoModal
+        visible={isCreatorInfoOpen}
+        onClose={() => setIsCreatorInfoOpen(false)}
+      />
     </HeroWrapper>
   );
 }

--- a/apps/web/components/Feature/ProfileLayout/Layout1/Hero/styles.ts
+++ b/apps/web/components/Feature/ProfileLayout/Layout1/Hero/styles.ts
@@ -146,10 +146,16 @@ export const MoreText = styled.span`
   color: ${({ theme }) => theme.colors.primary.BLACK};
 `;
 
-export const MoreTextLabel = styled(MonoText).attrs(({ theme }) => ({
-  $use: "Body_SemiBold",
-  color: theme.colors.primary.BLACK,
-}))``;
+export const MoreTextLabel = styled.button`
+  border: 0;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+
+  ${MonoText} {
+    text-decoration: underline;
+  }
+`;
 
 export const TabsWrapper = styled.div`
   margin-top: 24px;

--- a/apps/web/components/Feature/ProfileLayout/Layout2/Home/CreatorInfoModal.tsx
+++ b/apps/web/components/Feature/ProfileLayout/Layout2/Home/CreatorInfoModal.tsx
@@ -20,6 +20,7 @@ import {
   Section,
   ShareButton,
 } from "./CreatorInfoModal.styles";
+import { MODAL_PADDINGS } from "@/lib/theme/tokens";
 
 type CreatorInfoModalProps = {
   visible: boolean;
@@ -40,7 +41,7 @@ export default function CreatorInfoModal({
       onClose={onClose}
       size="md"
       height="570px"
-      padding="start"
+      padding={MODAL_PADDINGS.start}
       borderRadius="8px"
       showCloseButton={false}
     >


### PR DESCRIPTION
## Description

Fixes inconsistent `/about` profile sub-routes across profile layouts to prevent broken navigation and 404 pages.

### Changes

- Updated profile navigation behavior to avoid invalid routes.

Closes #717

## Type of change

https://github.com/user-attachments/assets/e3328375-a1f1-4de3-8ec8-3618778f7746


