### PR TITLE
838: FEAT: Update profile Name & image api on creator layouts 

### DIFF
--- a/apps/web/components/Feature/ProfileLayout/Hero/Sections/CenteredCover.tsx
+++ b/apps/web/components/Feature/ProfileLayout/Hero/Sections/CenteredCover.tsx
@@ -2,13 +2,13 @@
 
 import { useTranslation } from "react-i18next";
 import coverImage from "@/assets/images/creators/creator_profile_hero3.png";
-import avatarImage from "@/assets/images/creators/profile_pic3.png";
 import CreatorInfoModal from "@/components/Feature/ProfileLayout/shared/CreatorInfoModal";
+import CreatorChannelAvatar from "@/components/Feature/ProfileLayout/shared/CreatorChannelAvatar";
 import HeroTabs from "@/components/Feature/ProfileLayout/Hero/HeroTabs";
+import { useCreatorChannelProfile } from "@/hooks/useCreatorChannelProfile";
 import { useTabbedHeroState } from "@/hooks/useTabbedHeroState";
 import { CREATE_PROFILE_HOME } from "@/utils/translationKeys";
 import {
-  AvatarImage,
   AvatarWrapCentered,
   BioText,
   CoverFrameFull,
@@ -23,6 +23,8 @@ export default function CenteredCoverSection() {
   const { t } = useTranslation();
   const tabState = useTabbedHeroState();
   const { isAboutOpen, closeAbout } = tabState;
+  const { displayName, avatarUrl, initial } = useCreatorChannelProfile();
+  const creatorName = displayName;
 
   return (
     <HeroWrapperCentered>
@@ -38,15 +40,15 @@ export default function CenteredCoverSection() {
 
       <InfoSection>
         <AvatarWrapCentered>
-          <AvatarImage
-            src={avatarImage}
-            alt={t(CREATE_PROFILE_HOME.title)}
-            fill
+          <CreatorChannelAvatar
+            avatarUrl={avatarUrl}
+            initial={initial}
+            alt={creatorName || t(CREATE_PROFILE_HOME.title)}
             sizes="180px"
           />
         </AvatarWrapCentered>
 
-        <NameText>{t(CREATE_PROFILE_HOME.title)}</NameText>
+        <NameText>{creatorName}</NameText>
         <UploadsText>
           {t(CREATE_PROFILE_HOME.uploads, { count: 76 })}
         </UploadsText>

--- a/apps/web/components/Feature/ProfileLayout/Hero/Sections/ProfileCover.tsx
+++ b/apps/web/components/Feature/ProfileLayout/Hero/Sections/ProfileCover.tsx
@@ -2,13 +2,13 @@
 
 import { useTranslation } from "react-i18next";
 import coverImage from "@/assets/images/creators/create_profile_hero1.png";
-import avatarImage from "@/assets/images/creators/profile_pic.png";
 import CreatorInfoModal from "@/components/Feature/ProfileLayout/shared/CreatorInfoModal";
+import CreatorChannelAvatar from "@/components/Feature/ProfileLayout/shared/CreatorChannelAvatar";
 import HeroTabs from "@/components/Feature/ProfileLayout/Hero/HeroTabs";
+import { useCreatorChannelProfile } from "@/hooks/useCreatorChannelProfile";
 import { useTabbedHeroState } from "@/hooks/useTabbedHeroState";
 import { CREATE_PROFILE_HOME } from "@/utils/translationKeys";
 import {
-  AvatarImage,
   AvatarWrap,
   ContentInner,
   CoverFrame,
@@ -31,6 +31,8 @@ export default function ProfileCoverSection() {
   const { t } = useTranslation();
   const tabState = useTabbedHeroState();
   const { isAboutOpen, openAbout, closeAbout } = tabState;
+  const { displayName, avatarUrl, initial } = useCreatorChannelProfile();
+  const creatorName = displayName;
 
   return (
     <HeroWrapper>
@@ -47,17 +49,17 @@ export default function ProfileCoverSection() {
       <ContentInner>
         <ProfileSection>
           <AvatarWrap>
-            <AvatarImage
-              src={avatarImage}
-              alt={t(CREATE_PROFILE_HOME.title)}
-              fill
+            <CreatorChannelAvatar
+              avatarUrl={avatarUrl}
+              initial={initial}
+              alt={creatorName || t(CREATE_PROFILE_HOME.title)}
               sizes="152px"
             />
           </AvatarWrap>
 
           <ProfileMeta>
             <CreatorName>
-              <CreatorNameText>{t(CREATE_PROFILE_HOME.title)}</CreatorNameText>
+              <CreatorNameText>{creatorName}</CreatorNameText>
             </CreatorName>
             <UploadCount>
               <UploadCountText>

--- a/apps/web/components/Feature/ProfileLayout/Hero/Sections/Story.tsx
+++ b/apps/web/components/Feature/ProfileLayout/Hero/Sections/Story.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import COLORS from "@repo/ui/colors";
 import heroImage from "@/assets/images/creators/creator_profile_hero.png";
 import { MonoText } from "@/components/UI/Monotext";
+import { useCreatorChannelProfile } from "@/hooks/useCreatorChannelProfile";
 import { CREATE_PROFILE_HOME } from "@/utils/translationKeys";
 import {
   HeroContent,
@@ -20,6 +21,7 @@ import {
 
 export default function StorySection() {
   const { t } = useTranslation();
+  const { displayName } = useCreatorChannelProfile();
 
   return (
     <HeroFrame>
@@ -47,7 +49,7 @@ export default function StorySection() {
 
             <StoryTitle>
               <MonoText $use="Heading2" color={COLORS.primary.WHITE}>
-                {t(CREATE_PROFILE_HOME.title)}
+                {displayName}
               </MonoText>
             </StoryTitle>
 

--- a/apps/web/components/Feature/ProfileLayout/Hero/styles.ts
+++ b/apps/web/components/Feature/ProfileLayout/Hero/styles.ts
@@ -133,6 +133,7 @@ export const AvatarWrapCentered = styled.div`
   margin-top: -82px;
   border-radius: 999px;
   overflow: hidden;
+  background: ${({ theme }) => theme.colors.neutral.GRAY_200};
 
   ${({ theme }) => theme.media.mobileMd} {
     width: 136px;

--- a/apps/web/components/Feature/ProfileLayout/Navbar/index.tsx
+++ b/apps/web/components/Feature/ProfileLayout/Navbar/index.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import { SearchIcon } from "@/assets/icons/searchBarIcon";
-import portrait1 from "@/assets/images/creators/profile_pic.png";
-import portrait2 from "@/assets/images/creators/creator-woman-gray-jacket.webp";
+import CreatorChannelAvatar from "@/components/Feature/ProfileLayout/shared/CreatorChannelAvatar";
 import { PATHS } from "@/utils/path";
 import { CREATE_PROFILE_HOME, NAV } from "@/utils/translationKeys";
 import { MonoText } from "@/components/UI/Monotext";
@@ -15,10 +13,10 @@ import CreatorInfoModal from "@/components/Feature/ProfileLayout/shared/CreatorI
 import {
   Brand,
   BrandAvatar,
-  BrandAvatarImage,
   BrandName,
 } from "@/components/Feature/ProfileLayout/pageStyles";
 import type { ProfileLayoutVariant } from "@/components/Feature/ProfileLayout/config";
+import { useCreatorChannelProfile } from "@/hooks/useCreatorChannelProfile";
 import { useCreatorNavItems } from "@/hooks/useCreatorChannelLayout";
 
 type ProfileNavbarProps = {
@@ -29,34 +27,22 @@ export default function ProfileNavbar({ variant }: ProfileNavbarProps) {
   const { t } = useTranslation();
   const showNavItems = variant === "2";
   const { navItems, isAboutOpen, closeAbout } = useCreatorNavItems();
-  const portrait = showNavItems ? portrait2 : portrait1;
+  const { displayName, avatarUrl, initial } = useCreatorChannelProfile();
+  const brandName = displayName;
 
   const brand = (
     <Brand href={PATHS.DASHBOARD_CREATOR}>
       <BrandAvatar>
-        {showNavItems ? (
-          <Image
-            src={portrait}
-            alt={t(CREATE_PROFILE_HOME.brandName)}
-            fill
-            sizes="40px"
-            style={{ objectFit: "cover" }}
-            priority
-          />
-        ) : (
-          <BrandAvatarImage
-            src={portrait}
-            alt={t(CREATE_PROFILE_HOME.brandName)}
-            fill
-            sizes="40px"
-            priority
-          />
-        )}
+        <CreatorChannelAvatar
+          avatarUrl={avatarUrl}
+          initial={initial}
+          alt={brandName || t(CREATE_PROFILE_HOME.brandName)}
+          sizes="40px"
+          initialUse="H4_SemiBold"
+        />
       </BrandAvatar>
       <BrandName>
-        <MonoText $use="Body_SemiBold">
-          {t(CREATE_PROFILE_HOME.brandName)}
-        </MonoText>
+        <MonoText $use="Body_SemiBold">{brandName}</MonoText>
       </BrandName>
     </Brand>
   );

--- a/apps/web/components/Feature/ProfileLayout/Navbar/index.tsx
+++ b/apps/web/components/Feature/ProfileLayout/Navbar/index.tsx
@@ -7,7 +7,11 @@ import { PATHS } from "@/utils/path";
 import { CREATE_PROFILE_HOME, NAV } from "@/utils/translationKeys";
 import { MonoText } from "@/components/UI/Monotext";
 import GenericButton from "@/components/UI/GenericButton";
-import { profileNavShellProps, VARIANT } from "@/utils/Constants";
+import {
+  CREATOR_CHANNEL_AVATAR_TEXT,
+  profileNavShellProps,
+  VARIANT,
+} from "@/utils/Constants";
 import NavBar from "@/components/Layout/Navbar";
 import CreatorInfoModal from "@/components/Feature/ProfileLayout/shared/CreatorInfoModal";
 import {
@@ -38,7 +42,7 @@ export default function ProfileNavbar({ variant }: ProfileNavbarProps) {
           initial={initial}
           alt={brandName || t(CREATE_PROFILE_HOME.brandName)}
           sizes="40px"
-          initialUse="H4_SemiBold"
+          initialUse={CREATOR_CHANNEL_AVATAR_TEXT.NAVBAR}
         />
       </BrandAvatar>
       <BrandName>

--- a/apps/web/components/Feature/ProfileLayout/Shell.tsx
+++ b/apps/web/components/Feature/ProfileLayout/Shell.tsx
@@ -5,6 +5,7 @@ import Footer from "@/components/Feature/ProfileLayout/shared/Footer";
 import ProfileNavbar from "@/components/Feature/ProfileLayout/Navbar";
 import type { ProfileLayoutVariant } from "@/components/Feature/ProfileLayout/config";
 import { Page as PageShell } from "@/components/Feature/ProfileLayout/pageStyles";
+import { useProfileSync } from "@/hooks/auth/useProfileSync";
 
 type ProfileShellProps = {
   variant: ProfileLayoutVariant;
@@ -12,6 +13,8 @@ type ProfileShellProps = {
 };
 
 export default function ProfileShell({ variant, children }: ProfileShellProps) {
+  useProfileSync();
+
   return (
     <PageShell>
       <ProfileNavbar variant={variant} />

--- a/apps/web/components/Feature/ProfileLayout/shared/CreatorChannelAvatar/index.tsx
+++ b/apps/web/components/Feature/ProfileLayout/shared/CreatorChannelAvatar/index.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { AvatarImage, AvatarInitial } from "./styles";
+
+type CreatorChannelAvatarProps = {
+  avatarUrl: string | null;
+  initial: string;
+  alt: string;
+  sizes: string;
+  initialUse?: "Heading2" | "H4_SemiBold" | "Heading3";
+};
+
+export default function CreatorChannelAvatar({
+  avatarUrl,
+  initial,
+  alt,
+  sizes,
+  initialUse = "Heading2",
+}: CreatorChannelAvatarProps) {
+  if (avatarUrl) {
+    return (
+      <AvatarImage src={avatarUrl} alt={alt} fill sizes={sizes} unoptimized />
+    );
+  }
+
+  return <AvatarInitial $use={initialUse}>{initial}</AvatarInitial>;
+}

--- a/apps/web/components/Feature/ProfileLayout/shared/CreatorChannelAvatar/index.tsx
+++ b/apps/web/components/Feature/ProfileLayout/shared/CreatorChannelAvatar/index.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import {
+  CREATOR_CHANNEL_AVATAR_TEXT,
+  type CreatorChannelAvatarTextUse,
+} from "@/utils/Constants";
 import { AvatarImage, AvatarInitial } from "./styles";
 
 type CreatorChannelAvatarProps = {
@@ -7,7 +11,7 @@ type CreatorChannelAvatarProps = {
   initial: string;
   alt: string;
   sizes: string;
-  initialUse?: "Heading2" | "H4_SemiBold" | "Heading3";
+  initialUse?: CreatorChannelAvatarTextUse;
 };
 
 export default function CreatorChannelAvatar({
@@ -15,7 +19,7 @@ export default function CreatorChannelAvatar({
   initial,
   alt,
   sizes,
-  initialUse = "Heading2",
+  initialUse = CREATOR_CHANNEL_AVATAR_TEXT.HERO,
 }: CreatorChannelAvatarProps) {
   if (avatarUrl) {
     return (

--- a/apps/web/components/Feature/ProfileLayout/shared/CreatorChannelAvatar/styles.ts
+++ b/apps/web/components/Feature/ProfileLayout/shared/CreatorChannelAvatar/styles.ts
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+import Image from "next/image";
+import { MonoText } from "@/components/UI/Monotext";
+
+export const AvatarImage = styled(Image)`
+  object-fit: cover;
+  object-position: center;
+`;
+
+export const AvatarInitial = styled(MonoText)`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: ${({ theme }) => theme.colors.gradient.PALE_GREEN};
+  color: ${({ theme }) => theme.colors.primary.BLACK};
+  user-select: none;
+`;

--- a/apps/web/hooks/auth/useStoredLoginUser.ts
+++ b/apps/web/hooks/auth/useStoredLoginUser.ts
@@ -36,3 +36,25 @@ export function getLoginUserInitial(user: LoginUser | null): string {
 export function getLoginUserEmail(user: LoginUser | null): string {
   return toTrimmedString(user?.email);
 }
+
+export function getLoginUserDisplayName(user: LoginUser | null): string {
+  const fullName = toTrimmedString(user?.fullName);
+  if (fullName) return fullName;
+
+  const firstName = toTrimmedString(user?.firstName);
+  const lastName = toTrimmedString(user?.lastName);
+  const combined = [firstName, lastName].filter(Boolean).join(" ");
+  if (combined) return combined;
+
+  return getLoginUserEmail(user);
+}
+
+export function getDisplayInitial(
+  displayName: string,
+  user: LoginUser | null,
+): string {
+  const trimmed = toTrimmedString(displayName);
+  if (trimmed) return trimmed.charAt(0).toUpperCase();
+
+  return getLoginUserInitial(user);
+}

--- a/apps/web/hooks/useCreatorChannelProfile.ts
+++ b/apps/web/hooks/useCreatorChannelProfile.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  mapCreatorProfileToForm,
+  type GetCreatorProfileResponse,
+} from "@/hooks/auth/creatorProfileApi";
+import {
+  getDisplayInitial,
+  getLoginUserDisplayName,
+  useStoredLoginUser,
+} from "@/hooks/auth/useStoredLoginUser";
+import { API } from "@/lib/http/api/endpoints";
+import { useGetAPI } from "@/lib/http/api/getApi";
+import { toTrimmedString } from "@/utils/Constants";
+import { displayCreatorName, getAvatarUrl } from "@/utils/creatorProfile";
+
+export function useCreatorChannelProfile(enabled = true) {
+  const storedUser = useStoredLoginUser();
+  const profileQuery = useGetAPI<GetCreatorProfileResponse>(
+    API.auth.creatorProfile,
+    undefined,
+    {
+      enabled,
+      retry: false,
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  const profile = profileQuery.data?.data;
+
+  const displayName = useMemo(() => {
+    if (profile) {
+      const fromProfile = displayCreatorName(mapCreatorProfileToForm(profile));
+      if (fromProfile) return fromProfile;
+
+      const fullName = toTrimmedString(profile.user?.fullName);
+      if (fullName) return fullName;
+    }
+
+    return getLoginUserDisplayName(storedUser);
+  }, [profile, storedUser]);
+
+  const avatarUrl = useMemo(() => {
+    const fromApi = getAvatarUrl(profile?.user?.avatarUrl);
+    if (fromApi) return fromApi;
+
+    return getAvatarUrl(
+      typeof storedUser?.avatarUrl === "string" ? storedUser.avatarUrl : null,
+    );
+  }, [profile, storedUser]);
+
+  const initial = useMemo(
+    () => getDisplayInitial(displayName, storedUser),
+    [displayName, storedUser],
+  );
+
+  return {
+    displayName,
+    avatarUrl,
+    initial,
+    isLoadingProfile: profileQuery.isLoading,
+  };
+}

--- a/apps/web/hooks/useCreatorChannelProfile.ts
+++ b/apps/web/hooks/useCreatorChannelProfile.ts
@@ -45,9 +45,7 @@ export function useCreatorChannelProfile(enabled = true) {
     const fromApi = getAvatarUrl(profile?.user?.avatarUrl);
     if (fromApi) return fromApi;
 
-    return getAvatarUrl(
-      typeof storedUser?.avatarUrl === "string" ? storedUser.avatarUrl : null,
-    );
+    return getAvatarUrl(storedUser?.avatarUrl);
   }, [profile, storedUser]);
 
   const initial = useMemo(

--- a/apps/web/utils/Constants.ts
+++ b/apps/web/utils/Constants.ts
@@ -1,5 +1,15 @@
+import type { typography } from "@repo/ui/typography";
 import { COLLECTIONS, HOME } from "./common";
 import { NavBarProps } from "./profile";
+
+export const CREATOR_CHANNEL_AVATAR_TEXT = {
+  HERO: "Heading2",
+  NAVBAR: "H4_SemiBold",
+  COMPACT: "Heading3",
+} as const satisfies Record<string, keyof typeof typography>;
+
+export type CreatorChannelAvatarTextUse =
+  (typeof CREATOR_CHANNEL_AVATAR_TEXT)[keyof typeof CREATOR_CHANNEL_AVATAR_TEXT];
 
 export * from "./variants";
 export * from "./media";


### PR DESCRIPTION
# Description
- FEAT: Update profile Name & image api on creator layouts 

Fixes #838

## Type of change
<img width="1914" height="460" alt="image" src="https://github.com/user-attachments/assets/2f05d86a-e9fe-4835-8dc8-bf14b231ef25" />
<img width="1914" height="590" alt="image" src="https://github.com/user-attachments/assets/236a83b9-7fde-4d12-920c-e28501463adb" />
<img width="1914" height="460" alt="image" src="https://github.com/user-attachments/assets/f6872de2-2523-4be6-9ffd-a91c668943ae" />
